### PR TITLE
feat: add xmpkit dependency and XMP metadata reading module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +331,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "built"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +365,12 @@ name = "by_address"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -362,6 +397,15 @@ name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cc"
@@ -447,6 +491,16 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -691,6 +745,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +791,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,6 +833,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecb"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "ecow"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +867,15 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "enum-ordinalize"
@@ -1036,6 +1128,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1641,6 +1743,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1680,6 +1792,47 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jobserver"
@@ -1927,6 +2080,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "lopdf"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7184fdea2bc3cd272a1acec4030c321a8f9875e877b3f92a53f2f6033fdc289"
+dependencies = [
+ "aes",
+ "bitflags 2.11.0",
+ "cbc",
+ "chrono",
+ "ecb",
+ "encoding_rs",
+ "flate2",
+ "getrandom 0.3.4",
+ "indexmap",
+ "itoa",
+ "jiff",
+ "log",
+ "md-5",
+ "nom 8.0.0",
+ "nom_locate",
+ "rand 0.9.2",
+ "rangemap",
+ "rayon",
+ "sha2",
+ "stringprep",
+ "thiserror",
+ "time",
+ "ttf-parser",
+ "weezl",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1943,6 +2128,16 @@ checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
  "cfg-if",
  "rayon",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
 ]
 
 [[package]]
@@ -2032,6 +2227,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "nom_locate"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b577e2d69827c4740cba2b52efaad1c4cc7c73042860b199710b3575c68438d"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -2327,6 +2533,7 @@ dependencies = [
  "typst",
  "typst-kit",
  "typst-pdf",
+ "xmpkit",
 ]
 
 [[package]]
@@ -2397,6 +2604,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "postcard"
@@ -2638,6 +2854,12 @@ checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
 ]
+
+[[package]]
+name = "rangemap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "rav1e"
@@ -3005,6 +3227,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3112,6 +3345,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 dependencies = [
  "float-cmp 0.9.0",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -3512,6 +3756,12 @@ name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "typst"
@@ -4533,6 +4783,17 @@ name = "xmp-writer"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce9e2f4a404d9ebffc0a9832cf4f50907220ba3d7fffa9099261a5cab52f2dd7"
+
+[[package]]
+name = "xmpkit"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e673ffc84da779aa711248d1bd5579e113b43f0095b63269cb804c61f7ec36b1"
+dependencies = [
+ "lopdf",
+ "quick-xml",
+ "thiserror",
+]
 
 [[package]]
 name = "y4m"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,9 @@ serde_yaml = "0.9"
 # Regex for parsing dates from folder names
 regex = "1.10"
 
+# XMP metadata reading
+xmpkit = "0.1"
+
 # Fast hashing for duplicate detection
 blake3 = "1.5"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,7 @@
 //! Command-line interface for the photobook solver.
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::{Parser, Subcommand};
-use photobook_solver::commands::{self};
 use std::path::PathBuf;
 
 // Handler modules for each command
@@ -41,6 +40,14 @@ pub enum Commands {
         /// Allow adding duplicate photos (by hash)
         #[arg(long)]
         allow_duplicates: bool,
+
+        /// Only include photos whose XMP metadata matches this regex
+        #[arg(long, value_name = "REGEX")]
+        filter_xmp: Option<String>,
+
+        /// Preview what would be added without writing anything
+        #[arg(long, short = 'd')]
+        dry: bool,
     },
 
     /// Calculate layout and generate preview or final PDF
@@ -159,7 +166,9 @@ pub enum ProjectCommands {
 impl Execute for Commands {
     fn execute(&self) -> Result<()> {
         match self {
-            Commands::Add { paths, allow_duplicates } => add::handle(paths.clone(), *allow_duplicates),
+            Commands::Add { paths, allow_duplicates, filter_xmp, dry } => {
+                add::handle(paths.clone(), *allow_duplicates, filter_xmp.clone(), *dry)
+            }
             Commands::Build { release, pages } => build::handle(*release, pages.clone()),
             Commands::Rebuild { page, range_start, range_end, flex, all } => {
                 rebuild::handle(*page, *range_start, *range_end, *flex, *all)

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -1,48 +1,95 @@
 //! Handler for `fotobuch add` command
 
-use anyhow::Context;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use photobook_solver::commands;
+use regex::Regex;
 use std::path::PathBuf;
 
-pub fn handle(paths: Vec<PathBuf>, allow_duplicates: bool) -> Result<()> {
+pub fn handle(
+    paths: Vec<PathBuf>,
+    allow_duplicates: bool,
+    filter_xmp: Option<String>,
+    dry: bool,
+) -> Result<()> {
     let project_root = std::env::current_dir()
         .context("Failed to determine current directory")?;
+
+    let xmp_filter = filter_xmp
+        .as_deref()
+        .map(|pat| Regex::new(pat).with_context(|| format!("Invalid --filter-xmp regex: {pat}")))
+        .transpose()?;
 
     let config = commands::AddConfig {
         paths,
         allow_duplicates,
+        xmp_filter,
+        dry_run: dry,
     };
 
     let result = commands::add(&project_root, &config)?;
 
+    if result.dry_run {
+        print_dry_run(&result);
+    } else {
+        print_result(&result);
+    }
+
+    Ok(())
+}
+
+fn print_result(result: &commands::AddResult) {
     if result.groups_added.is_empty() {
         println!("ℹ️  No new photos added (all skipped).");
     } else {
-        println!("✅ Added {} photos in {} groups", 
+        println!(
+            "✅ Added {} photos in {} groups",
             result.groups_added.iter().map(|g| g.photo_count).sum::<usize>(),
             result.groups_added.len()
         );
-        
         for group in &result.groups_added {
-            println!("   📁 {} — {} photos ({})", 
-                group.name, 
-                group.photo_count, 
-                group.timestamp
+            println!(
+                "   📁 {} — {} photos ({})",
+                group.name, group.photo_count, group.timestamp
             );
         }
     }
 
+    print_shared_stats(result);
+}
+
+fn print_dry_run(result: &commands::AddResult) {
+    println!("🔍 Dry run — no changes written.\n");
+
+    if result.groups_added.is_empty() {
+        println!("ℹ️  No photos would be added.");
+    } else {
+        println!(
+            "Would add {} photos in {} groups:",
+            result.groups_added.iter().map(|g| g.photo_count).sum::<usize>(),
+            result.groups_added.len()
+        );
+        for group in &result.groups_added {
+            println!(
+                "   📁 {} — {} photos ({})",
+                group.name, group.photo_count, group.timestamp
+            );
+        }
+    }
+
+    print_shared_stats(result);
+}
+
+fn print_shared_stats(result: &commands::AddResult) {
+    if result.xmp_filtered > 0 {
+        println!("🔎 Filtered {} photos by XMP metadata", result.xmp_filtered);
+    }
     if result.skipped > 0 {
         println!("⏭️  Skipped {} duplicate photos", result.skipped);
     }
-
     if !result.warnings.is_empty() {
         println!("⚠️  Warnings:");
         for warning in &result.warnings {
             println!("   - {}", warning);
         }
     }
-
-    Ok(())
 }

--- a/src/cli/project.rs
+++ b/src/cli/project.rs
@@ -30,9 +30,7 @@ pub fn handle(command: ProjectSubcommand) -> Result<()> {
             parent_dir,
             quiet,
         } => {
-            let parent = parent_dir
-                .as_ref()
-                .map(|p| p.as_path())
+            let parent = parent_dir.as_deref()
                 .unwrap_or_else(|| std::path::Path::new("."));
 
             let config = commands::project::new::NewConfig {

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -70,8 +70,8 @@ pub struct AddResult {
 /// 6. Sort groups by sort_key — skipped in dry-run
 /// 7. Commit changes via StateManager — skipped in dry-run
 pub fn add(project_root: &Path, config: &AddConfig) -> Result<AddResult> {
-    let mut mgr = StateManager::open(project_root)
-        .context("Failed to open project via StateManager")?;
+    let mut mgr =
+        StateManager::open(project_root).context("Failed to open project via StateManager")?;
 
     let mut existing_paths: HashSet<PathBuf> = mgr
         .state
@@ -105,7 +105,7 @@ pub fn add(project_root: &Path, config: &AddConfig) -> Result<AddResult> {
                 let before = scanned_group.files.len();
                 scanned_group
                     .files
-                    .retain(|f| xmp::xmp_matches(Path::new(&f.source), pattern));
+                    .retain(|f| xmp::xmp_matches(Path::new(&f.source), pattern).unwrap_or(true));
                 total_xmp_filtered += before - scanned_group.files.len();
             }
 

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -12,22 +12,28 @@ pub use deduplication::deduplicate;
 pub use merge::merge_group;
 
 use anyhow::{Context, Result};
+use regex::Regex;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use crate::input::scanner;
+use crate::input::xmp;
 use crate::state_manager::StateManager;
 
 /// Configuration for adding photos
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct AddConfig {
     /// Directories or individual files to add
     pub paths: Vec<PathBuf>,
     /// Allow adding files with identical content (hash collision)
     pub allow_duplicates: bool,
+    /// When set, only include photos whose XMP metadata matches this regex
+    pub xmp_filter: Option<Regex>,
+    /// Preview mode: scan and report what would be added without touching the project
+    pub dry_run: bool,
 }
 
-/// Summary of a single added group
+/// Summary of a single added (or would-be-added) group
 #[derive(Debug)]
 pub struct GroupSummary {
     /// Group name (relative path from add argument)
@@ -41,51 +47,52 @@ pub struct GroupSummary {
 /// Result of adding photos
 #[derive(Debug)]
 pub struct AddResult {
-    /// Groups that were added
+    /// Groups that were added (or would be added in dry-run mode)
     pub groups_added: Vec<GroupSummary>,
     /// Number of photos that were skipped (already exist)
     pub skipped: usize,
+    /// Number of photos that were excluded by the XMP filter
+    pub xmp_filtered: usize,
     /// Warnings about duplicates or other issues
     pub warnings: Vec<String>,
+    /// Whether this was a dry run (no changes written)
+    pub dry_run: bool,
 }
 
-/// Add photos to the project
+/// Add photos to the project (or preview what would be added with `dry_run`).
 ///
 /// # Steps
-/// 1. Open StateManager (commits any manual edits)
+/// 1. Open StateManager (commits any manual edits) — skipped in dry-run
 /// 2. Scan directories for photo files
-/// 3. Deduplicate (path and hash check)
-/// 4. Merge groups (extend existing or add new)
-/// 5. Sort groups by sort_key
-/// 6. Commit changes via StateManager
-///
-/// # Arguments
-/// * `project_root` - Root directory of the fotobuch project (containing .git)
-/// * `config` - Configuration (paths to add, duplicate policy)
-///
-/// # Returns
-/// Summary of added groups, skipped photos, and warnings
+/// 3. Apply XMP filter (if configured)
+/// 4. Deduplicate (path and hash check)
+/// 5. Merge groups (extend existing or add new) — skipped in dry-run
+/// 6. Sort groups by sort_key — skipped in dry-run
+/// 7. Commit changes via StateManager — skipped in dry-run
 pub fn add(project_root: &Path, config: &AddConfig) -> Result<AddResult> {
-    // Step 1: Open StateManager
     let mut mgr = StateManager::open(project_root)
         .context("Failed to open project via StateManager")?;
 
-    // Step 2: Collect existing paths and hashes
-    let mut existing_paths = HashSet::new();
-    let mut existing_hashes = HashSet::new();
+    let mut existing_paths: HashSet<PathBuf> = mgr
+        .state
+        .photos
+        .iter()
+        .flat_map(|g| g.files.iter())
+        .map(|f| PathBuf::from(&f.source))
+        .collect();
 
-    for group in &mgr.state.photos {
-        for file in &group.files {
-            existing_paths.insert(PathBuf::from(&file.source));
-            if !file.hash.is_empty() {
-                existing_hashes.insert(file.hash.clone());
-            }
-        }
-    }
+    let mut existing_hashes: HashSet<String> = mgr
+        .state
+        .photos
+        .iter()
+        .flat_map(|g| g.files.iter())
+        .filter(|f| !f.hash.is_empty())
+        .map(|f| f.hash.clone())
+        .collect();
 
-    // Step 3: Scan directories
     let mut all_warnings = Vec::new();
     let mut total_skipped = 0;
+    let mut total_xmp_filtered = 0;
     let mut groups_added = Vec::new();
 
     for path in &config.paths {
@@ -93,7 +100,15 @@ pub fn add(project_root: &Path, config: &AddConfig) -> Result<AddResult> {
             .with_context(|| format!("Failed to scan {}", path.display()))?;
 
         for mut scanned_group in scanned_groups {
-            // Step 4: Deduplicate
+            // Apply XMP filter before dedup (cheap to skip files early)
+            if let Some(pattern) = &config.xmp_filter {
+                let before = scanned_group.files.len();
+                scanned_group
+                    .files
+                    .retain(|f| xmp::xmp_matches(Path::new(&f.source), pattern));
+                total_xmp_filtered += before - scanned_group.files.len();
+            }
+
             let (kept_files, skipped, warnings) = deduplicate(
                 &mut scanned_group.files,
                 &existing_paths,
@@ -104,12 +119,11 @@ pub fn add(project_root: &Path, config: &AddConfig) -> Result<AddResult> {
             total_skipped += skipped;
             all_warnings.extend(warnings);
 
-            // Skip empty groups (all photos were duplicates)
             if kept_files.is_empty() {
                 continue;
             }
 
-            // Update existing paths/hashes with newly kept files
+            // Track newly seen paths/hashes to catch cross-group duplicates
             for file in &kept_files {
                 existing_paths.insert(PathBuf::from(&file.source));
                 if !file.hash.is_empty() {
@@ -117,15 +131,14 @@ pub fn add(project_root: &Path, config: &AddConfig) -> Result<AddResult> {
                 }
             }
 
-            // Store summary before merge
             let group_name = scanned_group.group.clone();
             let photo_count = kept_files.len();
             let timestamp = scanned_group.sort_key.clone();
 
-            scanned_group.files = kept_files;
-
-            // Step 5: Merge group
-            merge_group(&mut mgr.state.photos, scanned_group);
+            if !config.dry_run {
+                scanned_group.files = kept_files;
+                merge_group(&mut mgr.state.photos, scanned_group);
+            }
 
             groups_added.push(GroupSummary {
                 name: group_name,
@@ -135,21 +148,22 @@ pub fn add(project_root: &Path, config: &AddConfig) -> Result<AddResult> {
         }
     }
 
-    // Step 6: Sort groups by sort_key
-    mgr.state.photos.sort_by(|a, b| a.sort_key.cmp(&b.sort_key));
+    if !config.dry_run {
+        mgr.state.photos.sort_by(|a, b| a.sort_key.cmp(&b.sort_key));
 
-    // Step 7: Commit via StateManager
-    let total_photos: usize = groups_added.iter().map(|g| g.photo_count).sum();
-    let commit_msg = format!(
-        "add: {} photos in {} groups",
-        total_photos,
-        groups_added.len()
-    );
-    mgr.finish(&commit_msg)?;
+        let total_photos: usize = groups_added.iter().map(|g| g.photo_count).sum();
+        mgr.finish(&format!(
+            "add: {} photos in {} groups",
+            total_photos,
+            groups_added.len()
+        ))?;
+    }
 
     Ok(AddResult {
         groups_added,
         skipped: total_skipped,
+        xmp_filtered: total_xmp_filtered,
         warnings: all_warnings,
+        dry_run: config.dry_run,
     })
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -3,4 +3,5 @@
 pub mod loader;
 pub mod metadata;
 pub mod scanner;
+pub mod xmp;
 // pub mod grouper; // Will be added in Commit 5

--- a/src/input/xmp.rs
+++ b/src/input/xmp.rs
@@ -1,0 +1,45 @@
+//! XMP metadata reading and filtering.
+//!
+//! Uses `xmpkit` (pure Rust) to extract the serialized XMP packet from image
+//! files and match it against a user-supplied regex pattern.
+
+use regex::Regex;
+use std::path::Path;
+use tracing::debug;
+use xmpkit::XmpFile;
+
+/// Returns `true` when the file's XMP packet contains a match for `pattern`.
+///
+/// Files without XMP metadata return `false` — they are excluded by the filter.
+pub fn xmp_matches(path: &Path, pattern: &Regex) -> bool {
+    let Some(packet) = read_xmp_packet(path) else {
+        debug!("No XMP found in {:?}, excluding from filter", path);
+        return false;
+    };
+    pattern.is_match(&packet)
+}
+
+/// Reads and serializes the full XMP packet from a file as an XML string.
+///
+/// Returns `None` when the file contains no XMP metadata or cannot be read.
+fn read_xmp_packet(path: &Path) -> Option<String> {
+    let mut xmp_file = XmpFile::new();
+    xmp_file.open_with(path, Default::default()).ok()?;
+    xmp_file.get_xmp()?.serialize_packet().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use regex::Regex;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_xmp_matches_no_xmp_returns_false() {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(b"not an image").unwrap();
+        let re = Regex::new(".*").unwrap();
+        assert!(!xmp_matches(f.path(), &re));
+    }
+}

--- a/src/input/xmp.rs
+++ b/src/input/xmp.rs
@@ -10,13 +10,13 @@ use xmpkit::XmpFile;
 
 /// Returns `true` when the file's XMP packet contains a match for `pattern`.
 ///
-/// Files without XMP metadata return `false` — they are excluded by the filter.
-pub fn xmp_matches(path: &Path, pattern: &Regex) -> bool {
+/// Files without XMP metadata return None
+pub fn xmp_matches(path: &Path, pattern: &Regex) -> Option<bool> {
     let Some(packet) = read_xmp_packet(path) else {
-        debug!("No XMP found in {:?}, excluding from filter", path);
-        return false;
+        debug!("No XMP found in {:?}, ", path);
+        return None;
     };
-    pattern.is_match(&packet)
+    Some(pattern.is_match(&packet))
 }
 
 /// Reads and serializes the full XMP packet from a file as an XML string.
@@ -40,6 +40,6 @@ mod tests {
         let mut f = NamedTempFile::new().unwrap();
         f.write_all(b"not an image").unwrap();
         let re = Regex::new(".*").unwrap();
-        assert!(!xmp_matches(f.path(), &re));
+        assert!(xmp_matches(f.path(), &re).is_none());
     }
 }

--- a/tests/add_test.rs
+++ b/tests/add_test.rs
@@ -7,6 +7,7 @@ use photobook_solver::dto_models::ProjectState;
 use regex::Regex;
 use std::fs;
 use std::path::PathBuf;
+use std::process::Command;
 use tempfile::TempDir;
 
 /// Helper to create a test project
@@ -294,6 +295,89 @@ fn test_xmp_filter_with_no_match_excludes_all() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_xmp_filter_matches_modified_description() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let project_root = create_test_project(&temp_dir)?;
+
+    // Copy test_photos_unique into temp directory
+    let temp_photos = temp_dir.path().join("test_photos");
+    fs::create_dir_all(&temp_photos)?;
+    
+    let source_photos = test_photos_path();
+    copy_dir_recursive(&source_photos, &temp_photos)?;
+
+    // Manipulate one photo (photo2.jpg from group2) using exiftool to set XMP description
+    let photo_to_modify = temp_photos.join("group2/photo2.jpg");
+    
+    // Use exiftool to set XMP description field
+    let output = Command::new("exiftool")
+        .arg("-XMP:Description=HIER_STEHT_WAS")
+        .arg("-overwrite_original")
+        .arg(&photo_to_modify)
+        .output()
+        .expect("Failed to execute exiftool");
+    
+    assert!(output.status.success(), 
+        "exiftool failed: {}", 
+        String::from_utf8_lossy(&output.stderr));
+
+    // Add photos with XMP filter that matches ".*STEHT.*"
+    let add_config = AddConfig {
+        paths: vec![temp_photos],
+        allow_duplicates: false,
+        xmp_filter: Some(Regex::new(r".*STEHT.*")?),
+        dry_run: false,
+    };
+    let result = add(&project_root, &add_config)?;
+
+    // Verify that exactly 2 photos were filtered out (xmp_filtered = 2)
+    assert_eq!(result.xmp_filtered, 2, "Should have filtered out 2 photos without matching XMP");
+    
+    // Verify that exactly 1 group was added with 1 photo
+    assert_eq!(result.groups_added.len(), 1, "Should have added exactly 1 group");
+    assert_eq!(result.groups_added[0].photo_count, 1, "Group should contain exactly 1 photo");
+    
+    // Load YAML and verify only the modified photo was added
+    let yaml_path = project_root.join("testproject.yaml");
+    let state = ProjectState::load(&yaml_path)?;
+    
+    assert_eq!(state.photos.len(), 1, "Should have exactly 1 photo group in YAML");
+    assert_eq!(state.photos[0].files.len(), 1, "Group should have exactly 1 photo file");
+    
+    // Verify the added photo is the one we modified (photo2.jpg)
+    let added_photo = &state.photos[0].files[0];
+    assert!(
+        added_photo.source.contains("photo2.jpg"),
+        "Added photo should be photo2.jpg, got: {}",
+        added_photo.source
+    );
+
+    Ok(())
+}
+
+/// Helper function to recursively copy directories
+fn copy_dir_recursive(src: &PathBuf, dst: &PathBuf) -> Result<()> {
+    fs::create_dir_all(dst)?;
+    
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_name = entry.file_name();
+        let dest_path = dst.join(&file_name);
+        
+        if path.is_dir() {
+            copy_dir_recursive(&path, &dest_path)?;
+        } else {
+            fs::copy(&path, &dest_path)?;
+        }
+    }
+    
+    Ok(())
+}
+
+
 
 #[test]
 fn test_add_handles_missing_directory() -> Result<()> {

--- a/tests/add_test.rs
+++ b/tests/add_test.rs
@@ -1,8 +1,8 @@
 //! Integration tests for `fotobuch add` command
 
 use anyhow::Result;
-use photobook_solver::commands::{add, AddConfig};
-use photobook_solver::commands::project::new::{project_new, NewConfig};
+use photobook_solver::commands::project::new::{NewConfig, project_new};
+use photobook_solver::commands::{AddConfig, add};
 use photobook_solver::dto_models::ProjectState;
 use regex::Regex;
 use std::fs;
@@ -47,26 +47,36 @@ fn test_add_single_directory_creates_groups() -> Result<()> {
     let result = add(&project_root, &add_config)?;
 
     // Verify result statistics
-    assert!(result.groups_added.len() > 0, "Should have added at least one group");
+    assert!(
+        result.groups_added.len() > 0,
+        "Should have added at least one group"
+    );
     assert_eq!(result.skipped, 0, "No duplicates on first add");
     assert_eq!(result.warnings.len(), 0, "No warnings on first add");
 
     // Load YAML and verify photos were added
     let yaml_path = project_root.join("testproject.yaml");
     let state = ProjectState::load(&yaml_path)?;
-    
+
     assert!(!state.photos.is_empty(), "Photos should be in YAML");
-    
+
     // Verify each photo has required fields
     for group in &state.photos {
         assert!(!group.group.is_empty(), "Group name should be set");
         assert!(!group.sort_key.is_empty(), "Sort key should be set");
-        
+
         for photo in &group.files {
             assert!(!photo.id.is_empty(), "Photo ID should be set");
             assert!(!photo.source.is_empty(), "Photo source should be set");
-            assert!(!photo.hash.is_empty(), "Photo hash should be persisted to YAML");
-            assert_eq!(photo.hash.len(), 64, "Blake3 hash should be 64 hex characters");
+            assert!(
+                !photo.hash.is_empty(),
+                "Photo hash should be persisted to YAML"
+            );
+            assert_eq!(
+                photo.hash.len(),
+                64,
+                "Blake3 hash should be 64 hex characters"
+            );
             assert!(photo.width_px > 0, "Photo width should be set");
             assert!(photo.height_px > 0, "Photo height should be set");
         }
@@ -77,7 +87,10 @@ fn test_add_single_directory_creates_groups() -> Result<()> {
     let head = repo.head()?;
     let commit = head.peel_to_commit()?;
     let message = commit.message().unwrap_or("");
-    assert!(message.contains("add:"), "Commit message should mention 'add'");
+    assert!(
+        message.contains("add:"),
+        "Commit message should mention 'add'"
+    );
 
     Ok(())
 }
@@ -96,15 +109,24 @@ fn test_add_duplicate_path_skips() -> Result<()> {
 
     // First add
     let result1 = add(&project_root, &add_config)?;
-    let photos_added_first = result1.groups_added.iter()
+    let photos_added_first = result1
+        .groups_added
+        .iter()
         .map(|g| g.photo_count)
         .sum::<usize>();
 
     // Second add (should skip all)
     let result2 = add(&project_root, &add_config)?;
-    
-    assert_eq!(result2.groups_added.len(), 0, "No new groups should be added");
-    assert_eq!(result2.skipped, photos_added_first, "All photos should be skipped");
+
+    assert_eq!(
+        result2.groups_added.len(),
+        0,
+        "No new groups should be added"
+    );
+    assert_eq!(
+        result2.skipped, photos_added_first,
+        "All photos should be skipped"
+    );
     assert_eq!(result2.warnings.len(), 0, "No warnings for path duplicates");
 
     Ok(())
@@ -144,13 +166,26 @@ fn test_add_merges_existing_group() -> Result<()> {
     let final_group_count = state2.photos.len();
     let final_photo_count: usize = state2.photos.iter().map(|g| g.files.len()).sum();
 
-    assert!(final_group_count > initial_group_count, "Should have added a new group");
-    assert!(final_photo_count > initial_photo_count, "Should have added new photos");
-    
+    assert!(
+        final_group_count > initial_group_count,
+        "Should have added a new group"
+    );
+    assert!(
+        final_photo_count > initial_photo_count,
+        "Should have added new photos"
+    );
+
     // Add group1 again (should merge with existing)
     let result3 = add(&project_root, &add_config1)?;
-    assert_eq!(result3.skipped, result1.groups_added.iter().map(|g| g.photo_count).sum::<usize>(),
-        "Should skip all photos from group1 as they already exist");
+    assert_eq!(
+        result3.skipped,
+        result1
+            .groups_added
+            .iter()
+            .map(|g| g.photo_count)
+            .sum::<usize>(),
+        "Should skip all photos from group1 as they already exist"
+    );
 
     Ok(())
 }
@@ -165,14 +200,14 @@ fn test_add_allow_duplicates_flag() -> Result<()> {
     let temp_photo_dir2 = temp_dir.path().join("photos2");
     fs::create_dir_all(&temp_photo_dir1)?;
     fs::create_dir_all(&temp_photo_dir2)?;
-    
+
     // Source file
     let source_file = test_photos_path().join("group1/photo1.jpg");
-    
+
     // Create copies in different directories
     let copy1 = temp_photo_dir1.join("photo.jpg");
     let copy2 = temp_photo_dir2.join("photo.jpg");
-    
+
     fs::copy(&source_file, &copy1)?;
     fs::copy(&source_file, &copy2)?;
 
@@ -184,7 +219,14 @@ fn test_add_allow_duplicates_flag() -> Result<()> {
         dry_run: false,
     };
     let result1 = add(&project_root, &add_config1)?;
-    assert_eq!(result1.groups_added.iter().map(|g| g.photo_count).sum::<usize>(), 1);
+    assert_eq!(
+        result1
+            .groups_added
+            .iter()
+            .map(|g| g.photo_count)
+            .sum::<usize>(),
+        1
+    );
 
     // Try to add second directory (same hash) without allow_duplicates
     let add_config2 = AddConfig {
@@ -194,10 +236,16 @@ fn test_add_allow_duplicates_flag() -> Result<()> {
         dry_run: false,
     };
     let result2 = add(&project_root, &add_config2)?;
-    
+
     assert_eq!(result2.skipped, 1, "Should skip hash duplicate");
-    assert!(result2.warnings.len() > 0, "Should warn about hash duplicate");
-    assert!(result2.warnings[0].contains("Duplicate"), "Warning should mention duplicate");
+    assert!(
+        result2.warnings.len() > 0,
+        "Should warn about hash duplicate"
+    );
+    assert!(
+        result2.warnings[0].contains("Duplicate"),
+        "Warning should mention duplicate"
+    );
 
     // Now add second directory with allow_duplicates = true
     let add_config3 = AddConfig {
@@ -207,9 +255,20 @@ fn test_add_allow_duplicates_flag() -> Result<()> {
         dry_run: false,
     };
     let result3 = add(&project_root, &add_config3)?;
-    assert_eq!(result3.groups_added.iter().map(|g| g.photo_count).sum::<usize>(), 1, 
-        "Should add the duplicate when allowed");
-    assert_eq!(result3.warnings.len(), 0, "No warnings when duplicates allowed");
+    assert_eq!(
+        result3
+            .groups_added
+            .iter()
+            .map(|g| g.photo_count)
+            .sum::<usize>(),
+        1,
+        "Should add the duplicate when allowed"
+    );
+    assert_eq!(
+        result3.warnings.len(),
+        0,
+        "No warnings when duplicates allowed"
+    );
 
     Ok(())
 }
@@ -237,7 +296,7 @@ fn test_add_sorts_groups_by_sort_key() -> Result<()> {
     // Verify sort order
     for i in 1..state.photos.len() {
         assert!(
-            state.photos[i-1].sort_key <= state.photos[i].sort_key,
+            state.photos[i - 1].sort_key <= state.photos[i].sort_key,
             "Groups should be sorted by sort_key"
         );
     }
@@ -262,7 +321,10 @@ fn test_dry_run_does_not_write_state() -> Result<()> {
     let result = add(&project_root, &add_config)?;
 
     assert!(result.dry_run);
-    assert!(!result.groups_added.is_empty(), "Dry run should still report what would be added");
+    assert!(
+        !result.groups_added.is_empty(),
+        "Dry run should still report what would be added"
+    );
 
     let state_after = ProjectState::load(&yaml_path)?;
     assert_eq!(
@@ -275,7 +337,7 @@ fn test_dry_run_does_not_write_state() -> Result<()> {
 }
 
 #[test]
-fn test_xmp_filter_with_no_match_excludes_all() -> Result<()> {
+fn test_xmp_filter_with_no_match_excludes_nothing() -> Result<()> {
     let temp_dir = TempDir::new()?;
     let project_root = create_test_project(&temp_dir)?;
 
@@ -288,9 +350,10 @@ fn test_xmp_filter_with_no_match_excludes_all() -> Result<()> {
     };
     let result = add(&project_root, &add_config)?;
 
-    assert!(
-        result.groups_added.is_empty(),
-        "All photos should be excluded when XMP filter matches nothing"
+    assert_eq!(
+        result.groups_added.len(),
+        2,
+        "All photos should not be excluded when XMP filter matches nothing"
     );
 
     Ok(())
@@ -304,24 +367,35 @@ fn test_xmp_filter_matches_modified_description() -> Result<()> {
     // Copy test_photos_unique into temp directory
     let temp_photos = temp_dir.path().join("test_photos");
     fs::create_dir_all(&temp_photos)?;
-    
+
     let source_photos = test_photos_path();
     copy_dir_recursive(&source_photos, &temp_photos)?;
 
+    // Use exiftool to set XMP description field
+    Command::new("exiftool")
+        .arg("-XMP:Description=LEER")
+        .arg("-overwrite_original")
+        .arg(temp_photos.join("group1/photo1.jpg"))
+        .arg(temp_photos.join("group2/photo3.jpg"))
+        .output()
+        .expect("Failed to execute exiftool");
+
     // Manipulate one photo (photo2.jpg from group2) using exiftool to set XMP description
-    let photo_to_modify = temp_photos.join("group2/photo2.jpg");
-    
+    let photo_to_match = temp_photos.join("group2/photo2.jpg");
+
     // Use exiftool to set XMP description field
     let output = Command::new("exiftool")
         .arg("-XMP:Description=HIER_STEHT_WAS")
         .arg("-overwrite_original")
-        .arg(&photo_to_modify)
+        .arg(&photo_to_match)
         .output()
         .expect("Failed to execute exiftool");
-    
-    assert!(output.status.success(), 
-        "exiftool failed: {}", 
-        String::from_utf8_lossy(&output.stderr));
+
+    assert!(
+        output.status.success(),
+        "exiftool failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     // Add photos with XMP filter that matches ".*STEHT.*"
     let add_config = AddConfig {
@@ -333,19 +407,37 @@ fn test_xmp_filter_matches_modified_description() -> Result<()> {
     let result = add(&project_root, &add_config)?;
 
     // Verify that exactly 2 photos were filtered out (xmp_filtered = 2)
-    assert_eq!(result.xmp_filtered, 2, "Should have filtered out 2 photos without matching XMP");
-    
+    assert_eq!(
+        result.xmp_filtered, 2,
+        "Should have filtered out 2 photos without matching XMP"
+    );
+
     // Verify that exactly 1 group was added with 1 photo
-    assert_eq!(result.groups_added.len(), 1, "Should have added exactly 1 group");
-    assert_eq!(result.groups_added[0].photo_count, 1, "Group should contain exactly 1 photo");
-    
+    assert_eq!(
+        result.groups_added.len(),
+        1,
+        "Should have added exactly 1 group"
+    );
+    assert_eq!(
+        result.groups_added[0].photo_count, 1,
+        "Group should contain exactly 1 photo"
+    );
+
     // Load YAML and verify only the modified photo was added
     let yaml_path = project_root.join("testproject.yaml");
     let state = ProjectState::load(&yaml_path)?;
-    
-    assert_eq!(state.photos.len(), 1, "Should have exactly 1 photo group in YAML");
-    assert_eq!(state.photos[0].files.len(), 1, "Group should have exactly 1 photo file");
-    
+
+    assert_eq!(
+        state.photos.len(),
+        1,
+        "Should have exactly 1 photo group in YAML"
+    );
+    assert_eq!(
+        state.photos[0].files.len(),
+        1,
+        "Group should have exactly 1 photo file"
+    );
+
     // Verify the added photo is the one we modified (photo2.jpg)
     let added_photo = &state.photos[0].files[0];
     assert!(
@@ -360,24 +452,22 @@ fn test_xmp_filter_matches_modified_description() -> Result<()> {
 /// Helper function to recursively copy directories
 fn copy_dir_recursive(src: &PathBuf, dst: &PathBuf) -> Result<()> {
     fs::create_dir_all(dst)?;
-    
+
     for entry in fs::read_dir(src)? {
         let entry = entry?;
         let path = entry.path();
         let file_name = entry.file_name();
         let dest_path = dst.join(&file_name);
-        
+
         if path.is_dir() {
             copy_dir_recursive(&path, &dest_path)?;
         } else {
             fs::copy(&path, &dest_path)?;
         }
     }
-    
+
     Ok(())
 }
-
-
 
 #[test]
 fn test_add_handles_missing_directory() -> Result<()> {
@@ -418,20 +508,29 @@ fn test_add_hashes_are_persisted() -> Result<()> {
     // Verify all photos are persisted
     let total_photos: usize = state.photos.iter().map(|g| g.files.len()).sum();
     let expected_photos: usize = result.groups_added.iter().map(|g| g.photo_count).sum();
-    
-    assert_eq!(total_photos, expected_photos, "All added photos should be in YAML");
-    
+
+    assert_eq!(
+        total_photos, expected_photos,
+        "All added photos should be in YAML"
+    );
+
     // Verify hashes are persisted to YAML
     for group in &state.photos {
         for photo in &group.files {
             assert!(!photo.id.is_empty(), "Photo ID should be set");
             assert!(!photo.source.is_empty(), "Photo source should be set");
             assert!(!photo.hash.is_empty(), "Hash should be persisted to YAML");
-            assert_eq!(photo.hash.len(), 64, "Blake3 hash should be 64 hex characters");
-            assert!(photo.hash.chars().all(|c| c.is_ascii_hexdigit()), "Hash should be hexadecimal");
+            assert_eq!(
+                photo.hash.len(),
+                64,
+                "Blake3 hash should be 64 hex characters"
+            );
+            assert!(
+                photo.hash.chars().all(|c| c.is_ascii_hexdigit()),
+                "Hash should be hexadecimal"
+            );
         }
     }
 
     Ok(())
 }
-

--- a/tests/add_test.rs
+++ b/tests/add_test.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use photobook_solver::commands::{add, AddConfig};
 use photobook_solver::commands::project::new::{project_new, NewConfig};
 use photobook_solver::dto_models::ProjectState;
+use regex::Regex;
 use std::fs;
 use std::path::PathBuf;
 use tempfile::TempDir;
@@ -38,6 +39,8 @@ fn test_add_single_directory_creates_groups() -> Result<()> {
     let add_config = AddConfig {
         paths: vec![test_photos_path()],
         allow_duplicates: false,
+        xmp_filter: None,
+        dry_run: false,
     };
 
     let result = add(&project_root, &add_config)?;
@@ -86,6 +89,8 @@ fn test_add_duplicate_path_skips() -> Result<()> {
     let add_config = AddConfig {
         paths: vec![test_photos_path()],
         allow_duplicates: false,
+        xmp_filter: None,
+        dry_run: false,
     };
 
     // First add
@@ -114,6 +119,8 @@ fn test_add_merges_existing_group() -> Result<()> {
     let add_config1 = AddConfig {
         paths: vec![group1_path.clone()],
         allow_duplicates: false,
+        xmp_filter: None,
+        dry_run: false,
     };
     let result1 = add(&project_root, &add_config1)?;
 
@@ -127,6 +134,8 @@ fn test_add_merges_existing_group() -> Result<()> {
     let add_config2 = AddConfig {
         paths: vec![group2_path],
         allow_duplicates: false,
+        xmp_filter: None,
+        dry_run: false,
     };
     let _result2 = add(&project_root, &add_config2)?;
 
@@ -170,6 +179,8 @@ fn test_add_allow_duplicates_flag() -> Result<()> {
     let add_config1 = AddConfig {
         paths: vec![temp_photo_dir1.clone()],
         allow_duplicates: false,
+        xmp_filter: None,
+        dry_run: false,
     };
     let result1 = add(&project_root, &add_config1)?;
     assert_eq!(result1.groups_added.iter().map(|g| g.photo_count).sum::<usize>(), 1);
@@ -178,6 +189,8 @@ fn test_add_allow_duplicates_flag() -> Result<()> {
     let add_config2 = AddConfig {
         paths: vec![temp_photo_dir2.clone()],
         allow_duplicates: false,
+        xmp_filter: None,
+        dry_run: false,
     };
     let result2 = add(&project_root, &add_config2)?;
     
@@ -189,6 +202,8 @@ fn test_add_allow_duplicates_flag() -> Result<()> {
     let add_config3 = AddConfig {
         paths: vec![temp_photo_dir2],
         allow_duplicates: true,
+        xmp_filter: None,
+        dry_run: false,
     };
     let result3 = add(&project_root, &add_config3)?;
     assert_eq!(result3.groups_added.iter().map(|g| g.photo_count).sum::<usize>(), 1, 
@@ -207,6 +222,8 @@ fn test_add_sorts_groups_by_sort_key() -> Result<()> {
     let add_config = AddConfig {
         paths: vec![test_photos_path()],
         allow_duplicates: false,
+        xmp_filter: None,
+        dry_run: false,
     };
     add(&project_root, &add_config)?;
 
@@ -228,6 +245,57 @@ fn test_add_sorts_groups_by_sort_key() -> Result<()> {
 }
 
 #[test]
+fn test_dry_run_does_not_write_state() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let project_root = create_test_project(&temp_dir)?;
+
+    let yaml_path = project_root.join("testproject.yaml");
+    let state_before = ProjectState::load(&yaml_path)?;
+
+    let add_config = AddConfig {
+        paths: vec![test_photos_path()],
+        allow_duplicates: false,
+        xmp_filter: None,
+        dry_run: true,
+    };
+    let result = add(&project_root, &add_config)?;
+
+    assert!(result.dry_run);
+    assert!(!result.groups_added.is_empty(), "Dry run should still report what would be added");
+
+    let state_after = ProjectState::load(&yaml_path)?;
+    assert_eq!(
+        state_before.photos.len(),
+        state_after.photos.len(),
+        "Dry run must not modify the persisted state"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_xmp_filter_with_no_match_excludes_all() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let project_root = create_test_project(&temp_dir)?;
+
+    // Pattern that matches nothing in XMP metadata of plain test fixtures
+    let add_config = AddConfig {
+        paths: vec![test_photos_path()],
+        allow_duplicates: false,
+        xmp_filter: Some(Regex::new(r"THIS_WILL_NEVER_MATCH_ANY_XMP_abc123xyz").unwrap()),
+        dry_run: true,
+    };
+    let result = add(&project_root, &add_config)?;
+
+    assert!(
+        result.groups_added.is_empty(),
+        "All photos should be excluded when XMP filter matches nothing"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_add_handles_missing_directory() -> Result<()> {
     let temp_dir = TempDir::new()?;
     let project_root = create_test_project(&temp_dir)?;
@@ -236,6 +304,8 @@ fn test_add_handles_missing_directory() -> Result<()> {
     let add_config = AddConfig {
         paths: vec![nonexistent_path],
         allow_duplicates: false,
+        xmp_filter: None,
+        dry_run: false,
     };
 
     // Should return an error for missing directory
@@ -253,6 +323,8 @@ fn test_add_hashes_are_persisted() -> Result<()> {
     let add_config = AddConfig {
         paths: vec![test_photos_path()],
         allow_duplicates: false,
+        xmp_filter: None,
+        dry_run: false,
     };
     let result = add(&project_root, &add_config)?;
 

--- a/tests/build_test.rs
+++ b/tests/build_test.rs
@@ -30,6 +30,8 @@ fn create_test_project_with_photos(temp_dir: &TempDir) -> Result<PathBuf> {
     let add_config = AddConfig {
         paths: vec![photos_path],
         allow_duplicates: false,
+        xmp_filter: None,
+        dry_run: false,
     };
     add(&project_root, &add_config)?;
 

--- a/tests/place_test.rs
+++ b/tests/place_test.rs
@@ -29,6 +29,8 @@ fn create_test_project_with_layout(temp_dir: &TempDir) -> Result<PathBuf> {
     let add_config = AddConfig {
         paths: vec![photos_path],
         allow_duplicates: false,
+        xmp_filter: None,
+        dry_run: false,
     };
     add(&project_root, &add_config)?;
 
@@ -84,6 +86,8 @@ fn test_place_requires_layout() -> Result<()> {
     let add_config = AddConfig {
         paths: vec![photos_path],
         allow_duplicates: false,
+        xmp_filter: None,
+        dry_run: false,
     };
     add(&project_root, &add_config)?;
 

--- a/tests/rebuild_test.rs
+++ b/tests/rebuild_test.rs
@@ -39,6 +39,8 @@ fn create_test_project_with_build(temp_dir: &TempDir) -> Result<PathBuf> {
     let add_config = AddConfig {
         paths: vec![photos_path],
         allow_duplicates: false,
+        xmp_filter: None,
+        dry_run: false,
     };
     add(&project_root, &add_config)?;
 
@@ -403,6 +405,8 @@ fn test_rebuild_without_layout_fails_except_all() -> Result<()> {
     let add_config = AddConfig {
         paths: vec![photos_path],
         allow_duplicates: false,
+        xmp_filter: None,
+        dry_run: false,
     };
     add(&project_root, &add_config)?;
 

--- a/tests/remove_test.rs
+++ b/tests/remove_test.rs
@@ -29,6 +29,8 @@ fn create_test_project_with_layout(temp_dir: &TempDir) -> Result<PathBuf> {
     let add_config = AddConfig {
         paths: vec![photos_path],
         allow_duplicates: false,
+        xmp_filter: None,
+        dry_run: false,
     };
     add(&project_root, &add_config)?;
 

--- a/tests/status_test.rs
+++ b/tests/status_test.rs
@@ -33,6 +33,8 @@ fn create_test_project_with_layout(temp_dir: &TempDir) -> Result<PathBuf> {
     let add_config = AddConfig {
         paths: vec![photos_path],
         allow_duplicates: false,
+        xmp_filter: None,
+        dry_run: false,
     };
     add(&project_root, &add_config)?;
 


### PR DESCRIPTION
Introduces `xmpkit` (pure Rust) for fast XMP packet extraction from
image files. The `input::xmp` module exposes `xmp_matches(path, regex)`
which serializes the full XMP packet and checks it against a pattern.
Files without XMP metadata return false (conservative exclusion).

https://claude.ai/code/session_01TjefjJWuS9mZGAm2U5V9Vf