### PR TITLE
Switch page and slot numbering from 1-based to 0-based

### DIFF
--- a/src/commands/page/combine.rs
+++ b/src/commands/page/combine.rs
@@ -9,7 +9,7 @@ use super::types::{PageMoveError, PageMoveResult, PagesExpr, ValidationError};
 
 /// Combine all given pages onto the first page and delete the rest.
 ///
-/// Pages in `pages_expr` must be 1-based. At least two pages required.
+/// Pages in `pages_expr` must be 0-based. At least two pages required.
 pub fn execute_combine(
     project_root: &Path,
     pages_expr: PagesExpr,
@@ -77,9 +77,9 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         setup_repo(&tmp, &state);
 
-        let pages = PagesExpr::from_range(1, 3);
+        let pages = PagesExpr::from_range(0, 2);
         let result = execute_combine(tmp.path(), pages).unwrap();
-        assert_eq!(result.pages_deleted, vec![2, 3]);
+        assert_eq!(result.pages_deleted, vec![1, 2]);
 
         let mgr = StateManager::open(tmp.path()).unwrap();
         assert_eq!(mgr.state.layout.len(), 1);
@@ -93,11 +93,11 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         setup_repo(&tmp, &state);
 
-        let pages = PagesExpr::single(1);
+        let pages = PagesExpr::single(0);
         let result = execute_combine(tmp.path(), pages);
         assert!(matches!(
             result,
-            Err(PageMoveError::Validation(ValidationError::CombineSinglePage(1)))
+            Err(PageMoveError::Validation(ValidationError::CombineSinglePage(0)))
         ));
     }
 }

--- a/src/commands/page/helpers.rs
+++ b/src/commands/page/helpers.rs
@@ -16,7 +16,7 @@ pub(crate) fn page_idx(page: u32, layout: &[LayoutPage]) -> Result<usize, Valida
 }
 
 /// Resolve slot numbers on a page to 0-based indices and validate they exist.
-/// Slot numbers are 1-based; open-ended ranges are resolved against the actual page size.
+/// Slot numbers are 0-based; open-ended ranges are resolved against the actual page size.
 pub(crate) fn resolve_slots(
     page: u32,
     slot_expr: &SlotExpr,
@@ -28,22 +28,19 @@ pub(crate) fn resolve_slots(
     for item in &slot_expr.items {
         match item {
             SlotItem::Single(s) => {
-                if *s == 0 || *s as usize > n_slots {
+                if *s as usize >= n_slots {
                     return Err(ValidationError::SlotNotFound { page, slot: *s });
                 }
-                result.push(*s as usize - 1);
+                result.push(*s as usize);
             }
             SlotItem::Range { from, to } => {
-                let start = from.unwrap_or(1);
-                let end = to.unwrap_or(n_slots as u32);
-                if start == 0 {
-                    return Err(ValidationError::SlotNotFound { page, slot: 0 });
-                }
-                if end as usize > n_slots {
+                let start = from.unwrap_or(0);
+                let end = to.unwrap_or(n_slots.saturating_sub(1) as u32);
+                if end as usize >= n_slots {
                     return Err(ValidationError::SlotNotFound { page, slot: end });
                 }
                 for s in start..=end {
-                    result.push(s as usize - 1);
+                    result.push(s as usize);
                 }
             }
         }
@@ -63,7 +60,7 @@ pub(super) fn photos_at_slots(
         if i >= layout[page_idx].photos.len() {
             return Err(ValidationError::SlotEmpty {
                 page: layout[page_idx].page as u32,
-                slot: i as u32 + 1,
+                slot: i as u32,
             });
         }
         photos.push(layout[page_idx].photos[i].clone());
@@ -72,7 +69,7 @@ pub(super) fn photos_at_slots(
 }
 
 /// Remove all pages with no photos from the layout.
-/// Returns the 1-based page numbers that were deleted.
+/// Returns the 0-based page numbers that were deleted.
 pub(crate) fn delete_empty_pages(layout: &mut Vec<LayoutPage>) -> Vec<u32> {
     let mut deleted = Vec::new();
     let mut i = 0;
@@ -212,20 +209,20 @@ mod tests {
     #[test]
     fn test_page_idx_valid() {
         let state = make_state_with_layout(vec![vec!["p0.jpg"], vec!["p1.jpg"]]);
-        assert_eq!(page_idx(1, &state.layout).unwrap(), 0);
-        assert_eq!(page_idx(2, &state.layout).unwrap(), 1);
+        assert_eq!(page_idx(0, &state.layout).unwrap(), 0);
+        assert_eq!(page_idx(1, &state.layout).unwrap(), 1);
     }
 
     #[test]
     fn test_page_idx_out_of_range() {
         let state = make_state_with_layout(vec![vec!["p0.jpg"]]);
         assert_eq!(
-            page_idx(2, &state.layout),
-            Err(ValidationError::PageNotFound(2))
+            page_idx(1, &state.layout),
+            Err(ValidationError::PageNotFound(1))
         );
         assert_eq!(
-            page_idx(0, &state.layout),
-            Err(ValidationError::PageNotFound(0))
+            page_idx(5, &state.layout),
+            Err(ValidationError::PageNotFound(5))
         );
     }
 
@@ -233,20 +230,20 @@ mod tests {
     fn test_resolve_slots_valid() {
         let state = make_state_with_layout(vec![vec!["p0.jpg", "p1.jpg", "p2.jpg"]]);
         // bounded range
-        assert_eq!(resolve_slots(1, &SlotExpr::from_range(1, 3), &state.layout).unwrap(), vec![0, 1, 2]);
-        // open end: 2.. → slots 2 and 3
-        assert_eq!(resolve_slots(1, &SlotExpr::from_open_end(2), &state.layout).unwrap(), vec![1, 2]);
-        // open start: ..2 → slots 1 and 2
-        assert_eq!(resolve_slots(1, &SlotExpr::from_open_start(2), &state.layout).unwrap(), vec![0, 1]);
+        assert_eq!(resolve_slots(0, &SlotExpr::from_range(0, 2), &state.layout).unwrap(), vec![0, 1, 2]);
+        // open end: 1.. → slots 1 and 2
+        assert_eq!(resolve_slots(0, &SlotExpr::from_open_end(1), &state.layout).unwrap(), vec![1, 2]);
+        // open start: ..1 → slots 0 and 1
+        assert_eq!(resolve_slots(0, &SlotExpr::from_open_start(1), &state.layout).unwrap(), vec![0, 1]);
     }
 
     #[test]
     fn test_resolve_slots_out_of_range() {
         let state = make_state_with_layout(vec![vec!["p0.jpg", "p1.jpg"]]);
-        let slots = SlotExpr::single(3);
+        let slots = SlotExpr::single(2);
         assert_eq!(
-            resolve_slots(1, &slots, &state.layout),
-            Err(ValidationError::SlotNotFound { page: 1, slot: 3 })
+            resolve_slots(0, &slots, &state.layout),
+            Err(ValidationError::SlotNotFound { page: 0, slot: 2 })
         );
     }
 }

--- a/src/commands/page/info.rs
+++ b/src/commands/page/info.rs
@@ -52,7 +52,7 @@ pub fn execute_info(
                     if let Some(pf) = photo_map.get(photo_id.as_str()) {
                         slots.push(SlotInfo {
                             page: p,
-                            slot: i as u32 + 1,
+                            slot: i as u32,
                             id: pf.id.clone(),
                             source: pf.source.clone(),
                             width_px: pf.width_px,
@@ -115,11 +115,11 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         setup_repo(&tmp, &state);
 
-        let result = execute_info(tmp.path(), Src::Pages(PagesExpr::single(1)), InfoFilter::default()).unwrap();
+        let result = execute_info(tmp.path(), Src::Pages(PagesExpr::single(0)), InfoFilter::default()).unwrap();
         assert_eq!(result.slots.len(), 2);
-        assert_eq!(result.slots[0].slot, 1);
+        assert_eq!(result.slots[0].slot, 0);
         assert_eq!(result.slots[0].id, "p0.jpg");
-        assert_eq!(result.slots[1].slot, 2);
+        assert_eq!(result.slots[1].slot, 1);
         assert_eq!(result.slots[0].total_page_slots, 2);
     }
 
@@ -131,7 +131,7 @@ mod tests {
 
         let result = execute_info(
             tmp.path(),
-            Src::Slots { page: 1, slots: SlotExpr::from_range(1, 2) },
+            Src::Slots { page: 0, slots: SlotExpr::from_range(0, 1) },
             InfoFilter::default(),
         ).unwrap();
         assert_eq!(result.slots.len(), 2);
@@ -144,7 +144,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         setup_repo(&tmp, &state);
 
-        let err = execute_info(tmp.path(), Src::Pages(PagesExpr::single(5)), InfoFilter::default()).unwrap_err();
-        assert!(err.to_string().contains("page 5"));
+        let err = execute_info(tmp.path(), Src::Pages(PagesExpr::single(99)), InfoFilter::default()).unwrap_err();
+        assert!(err.to_string().contains("page 99"));
     }
 }

--- a/src/commands/page/move_cmd.rs
+++ b/src/commands/page/move_cmd.rs
@@ -96,7 +96,7 @@ fn execute_move_to(
         DstMove::NewPageAfter(p) => {
             let after_idx = page_idx(*p, &mgr.state.layout)?;
             let new_idx = after_idx + 1;
-            let new_page_num = new_idx + 1; // will be renumbered by finish()
+            let new_page_num = new_idx; // will be renumbered by finish()
             mgr.state.layout.insert(
                 new_idx,
                 LayoutPage {
@@ -380,11 +380,11 @@ mod tests {
         setup_repo(&tmp, &state);
 
         let cmd = PageMoveCmd::Move {
-            src: Src::Pages(PagesExpr::single(2)),
-            dst: DstMove::Page(1),
+            src: Src::Pages(PagesExpr::single(1)),
+            dst: DstMove::Page(0),
         };
         let result = execute_move(tmp.path(), cmd).unwrap();
-        assert!(result.pages_deleted.contains(&2));
+        assert!(result.pages_deleted.contains(&1));
 
         let mgr = StateManager::open(tmp.path()).unwrap();
         assert_eq!(mgr.state.layout.len(), 1);
@@ -404,11 +404,11 @@ mod tests {
         setup_repo(&tmp, &state);
 
         let cmd = PageMoveCmd::Move {
-            src: Src::Pages(PagesExpr::single(1)),
+            src: Src::Pages(PagesExpr::single(0)),
             dst: DstMove::Unplace,
         };
         let result = execute_move(tmp.path(), cmd).unwrap();
-        assert_eq!(result.pages_deleted, vec![1]);
+        assert_eq!(result.pages_deleted, vec![0]);
         assert!(result.pages_modified.is_empty());
 
         let mgr = StateManager::open(tmp.path()).unwrap();
@@ -425,13 +425,13 @@ mod tests {
 
         let cmd = PageMoveCmd::Move {
             src: Src::Slots {
-                page: 1,
-                slots: SlotExpr::from_range(1, 2),
+                page: 0,
+                slots: SlotExpr::from_range(0, 1),
             },
             dst: DstMove::Unplace,
         };
         let result = execute_move(tmp.path(), cmd).unwrap();
-        assert_eq!(result.pages_modified, vec![1]);
+        assert_eq!(result.pages_modified, vec![0]);
         assert!(result.pages_deleted.is_empty());
 
         let mgr = StateManager::open(tmp.path()).unwrap();
@@ -450,10 +450,10 @@ mod tests {
 
         let cmd = PageMoveCmd::Move {
             src: Src::Slots {
-                page: 1,
-                slots: SlotExpr::single(1),
+                page: 0,
+                slots: SlotExpr::single(0),
             },
-            dst: DstMove::NewPageAfter(1),
+            dst: DstMove::NewPageAfter(0),
         };
         let result = execute_move(tmp.path(), cmd).unwrap();
         assert!(!result.pages_inserted.is_empty());
@@ -477,16 +477,16 @@ mod tests {
 
         let cmd = PageMoveCmd::Move {
             src: Src::Slots {
-                page: 2,
-                slots: SlotExpr::single(1),
+                page: 1,
+                slots: SlotExpr::single(0),
             },
-            dst: DstMove::NewPageAfter(1),
+            dst: DstMove::NewPageAfter(0),
         };
         let result = execute_move(tmp.path(), cmd).unwrap();
         assert!(!result.pages_inserted.is_empty());
 
         let mgr = StateManager::open(tmp.path()).unwrap();
-        // Original page 1, new page (with p1.jpg), original page 2 (with p2.jpg)
+        // Original page 0, new page (with p1.jpg), original page 1 (with p2.jpg)
         assert_eq!(mgr.state.layout.len(), 3);
         assert_eq!(mgr.state.layout[0].photos, vec!["p0.jpg"]);
         assert!(mgr.state.layout[1].photos.contains(&"p1.jpg".to_owned()));
@@ -503,16 +503,16 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         setup_repo(&tmp, &state);
 
-        // Move the only slot from page 1 to page 2 → page 1 becomes empty → deleted
+        // Move the only slot from page 0 to page 1 → page 0 becomes empty → deleted
         let cmd = PageMoveCmd::Move {
             src: Src::Slots {
-                page: 1,
-                slots: SlotExpr::single(1),
+                page: 0,
+                slots: SlotExpr::single(0),
             },
-            dst: DstMove::Page(2),
+            dst: DstMove::Page(1),
         };
         let result = execute_move(tmp.path(), cmd).unwrap();
-        assert!(result.pages_deleted.contains(&1));
+        assert!(result.pages_deleted.contains(&0));
 
         let mgr = StateManager::open(tmp.path()).unwrap();
         assert_eq!(mgr.state.layout.len(), 1);
@@ -529,16 +529,16 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         setup_repo(&tmp, &state);
 
-        // Unplace all slots from page 1 → page 1 becomes empty → deleted
+        // Unplace all slots from page 0 → page 0 becomes empty → deleted
         let cmd = PageMoveCmd::Move {
             src: Src::Slots {
-                page: 1,
-                slots: SlotExpr::from_range(1, 2),
+                page: 0,
+                slots: SlotExpr::from_range(0, 1),
             },
             dst: DstMove::Unplace,
         };
         let result = execute_move(tmp.path(), cmd).unwrap();
-        assert!(result.pages_deleted.contains(&1));
+        assert!(result.pages_deleted.contains(&0));
         assert!(result.pages_modified.is_empty());
 
         let mgr = StateManager::open(tmp.path()).unwrap();
@@ -558,13 +558,13 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         setup_repo(&tmp, &state);
 
-        // Equal-size block transposition: [1,2] ↔ [3,4]
+        // Equal-size block transposition: [0,1] ↔ [2,3]
         let cmd = PageMoveCmd::Swap {
-            left: Src::Pages(PagesExpr::from_range(1, 2)),
-            right: super::super::types::DstSwap::Pages(PagesExpr::from_range(3, 4)),
+            left: Src::Pages(PagesExpr::from_range(0, 1)),
+            right: super::super::types::DstSwap::Pages(PagesExpr::from_range(2, 3)),
         };
         let result = execute_move(tmp.path(), cmd).unwrap();
-        assert_eq!(result.pages_modified, vec![1, 2, 3, 4]);
+        assert_eq!(result.pages_modified, vec![0, 1, 2, 3]);
 
         let mgr = StateManager::open(tmp.path()).unwrap();
         assert_eq!(mgr.state.layout[0].photos, vec!["c1.jpg", "c2.jpg", "c3.jpg"]);
@@ -576,7 +576,7 @@ mod tests {
 
     #[test]
     fn test_execute_swap_page_range_unequal_sizes_with_middle() {
-        // [1,2] ↔ [4,5,6] with page 3 as middle
+        // [0,1] ↔ [3,4,5] with page 2 as middle
         // before: [a, b, M, c, d, e]
         // after:  [c, d, e, M, a, b]
         let state = make_state_with_layout(vec![
@@ -591,11 +591,11 @@ mod tests {
         setup_repo(&tmp, &state);
 
         let cmd = PageMoveCmd::Swap {
-            left: Src::Pages(PagesExpr::from_range(1, 2)),
-            right: super::super::types::DstSwap::Pages(PagesExpr::from_range(4, 6)),
+            left: Src::Pages(PagesExpr::from_range(0, 1)),
+            right: super::super::types::DstSwap::Pages(PagesExpr::from_range(3, 5)),
         };
         let result = execute_move(tmp.path(), cmd).unwrap();
-        assert_eq!(result.pages_modified, vec![1, 2, 4, 5, 6]);
+        assert_eq!(result.pages_modified, vec![0, 1, 3, 4, 5]);
 
         let mgr = StateManager::open(tmp.path()).unwrap();
         assert_eq!(mgr.state.layout[0].photos, vec!["c.jpg"]);
@@ -619,8 +619,8 @@ mod tests {
         setup_repo(&tmp, &state);
 
         let cmd = PageMoveCmd::Swap {
-            left: Src::Pages(PagesExpr::from_list(vec![1, 3])),
-            right: super::super::types::DstSwap::Pages(PagesExpr::from_list(vec![2, 4])),
+            left: Src::Pages(PagesExpr::from_list(vec![0, 2])),
+            right: super::super::types::DstSwap::Pages(PagesExpr::from_list(vec![1, 3])),
         };
         let err = execute_move(tmp.path(), cmd).unwrap_err();
         assert!(matches!(
@@ -640,8 +640,8 @@ mod tests {
         setup_repo(&tmp, &state);
 
         let cmd = PageMoveCmd::Swap {
-            left: Src::Pages(PagesExpr::from_range(1, 2)),
-            right: super::super::types::DstSwap::Pages(PagesExpr::from_range(2, 3)),
+            left: Src::Pages(PagesExpr::from_range(0, 1)),
+            right: super::super::types::DstSwap::Pages(PagesExpr::from_range(1, 2)),
         };
         let err = execute_move(tmp.path(), cmd).unwrap_err();
         assert!(matches!(
@@ -652,19 +652,19 @@ mod tests {
 
     #[test]
     fn test_execute_swap_same_page_slots_allowed() {
-        // swap 1:1 1:3 — slot 1 and slot 3 on the same page swap positions.
+        // swap 0:0 0:2 — slot 0 and slot 2 on the same page swap positions.
         let state = make_state_with_layout(vec![vec!["a.jpg", "b.jpg", "c.jpg"]]);
         let tmp = TempDir::new().unwrap();
         setup_repo(&tmp, &state);
 
         let cmd = PageMoveCmd::Swap {
             left: Src::Slots {
-                page: 1,
-                slots: SlotExpr::single(1),
+                page: 0,
+                slots: SlotExpr::single(0),
             },
             right: super::super::types::DstSwap::Slots {
-                page: 1,
-                slots: SlotExpr::single(3),
+                page: 0,
+                slots: SlotExpr::single(2),
             },
         };
         execute_move(tmp.path(), cmd).unwrap();
@@ -682,12 +682,12 @@ mod tests {
 
         let cmd = PageMoveCmd::Swap {
             left: Src::Slots {
-                page: 1,
-                slots: SlotExpr::from_range(1, 2),
+                page: 0,
+                slots: SlotExpr::from_range(0, 1),
             },
             right: super::super::types::DstSwap::Slots {
-                page: 1,
-                slots: SlotExpr::from_range(2, 3),
+                page: 0,
+                slots: SlotExpr::from_range(1, 2),
             },
         };
         let err = execute_move(tmp.path(), cmd).unwrap_err();

--- a/src/commands/page/split.rs
+++ b/src/commands/page/split.rs
@@ -10,7 +10,7 @@ use super::types::{PageMoveError, PageMoveResult, ValidationError};
 
 /// Split a page at a given slot: photos from `slot` onwards move to a new page after it.
 ///
-/// `page` and `slot` are 1-based.
+/// `page` and `slot` are 0-based.
 pub fn execute_split(
     project_root: &Path,
     page: u32,
@@ -21,14 +21,14 @@ pub fn execute_split(
     let idx = page_idx(page, &mgr.state.layout)?;
     let n_photos = mgr.state.layout[idx].photos.len();
 
-    if slot == 0 || slot as usize > n_photos {
+    if slot as usize >= n_photos {
         return Err(ValidationError::SlotNotFound { page, slot }.into());
     }
-    if slot == 1 {
+    if slot == 0 {
         return Err(ValidationError::SplitAtFirstSlot(page).into());
     }
 
-    let split_at = slot as usize - 1;
+    let split_at = slot as usize;
     let moved_photos: Vec<String> = mgr.state.layout[idx].photos[split_at..].to_vec();
     let moved_slots: Vec<_> = if split_at < mgr.state.layout[idx].slots.len() {
         mgr.state.layout[idx].slots[split_at..].to_vec()
@@ -43,13 +43,13 @@ pub fn execute_split(
     mgr.state.layout.insert(
         new_idx,
         LayoutPage {
-            page: (new_idx + 1) as usize, // will be renumbered by finish()
+            page: new_idx, // will be renumbered by finish()
             photos: moved_photos,
             slots: moved_slots,
         },
     );
 
-    let new_page_num = new_idx as u32 + 1;
+    let new_page_num = new_idx as u32;
     mgr.finish(&format!("page split: page {page} at slot {slot}"))?;
 
     Ok(PageMoveResult {
@@ -76,7 +76,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         setup_repo(&tmp, &state);
 
-        let result = execute_split(tmp.path(), 1, 3).unwrap();
+        let result = execute_split(tmp.path(), 0, 2).unwrap();
         assert!(!result.pages_inserted.is_empty());
 
         let mgr = StateManager::open(tmp.path()).unwrap();
@@ -92,10 +92,10 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         setup_repo(&tmp, &state);
 
-        let result = execute_split(tmp.path(), 1, 1);
+        let result = execute_split(tmp.path(), 0, 0);
         assert!(matches!(
             result,
-            Err(PageMoveError::Validation(ValidationError::SplitAtFirstSlot(1)))
+            Err(PageMoveError::Validation(ValidationError::SplitAtFirstSlot(0)))
         ));
     }
 }

--- a/src/commands/page/types.rs
+++ b/src/commands/page/types.rs
@@ -174,11 +174,11 @@ impl From<ValidationError> for PageMoveError {
 /// Summary of what a page command changed.
 #[derive(Debug)]
 pub struct PageMoveResult {
-    /// Pages whose photo list changed (need rebuild), 1-based.
+    /// Pages whose photo list changed (need rebuild), 0-based.
     pub pages_modified: Vec<u32>,
-    /// Pages that were newly inserted, 1-based.
+    /// Pages that were newly inserted, 0-based.
     pub pages_inserted: Vec<u32>,
-    /// Pages that were deleted, 1-based (original numbers before deletion).
+    /// Pages that were deleted, 0-based (original numbers before deletion).
     pub pages_deleted: Vec<u32>,
 }
 
@@ -209,9 +209,9 @@ impl InfoFilter {
 /// Per-slot info record returned by `execute_info`.
 #[derive(Debug, Clone)]
 pub struct SlotInfo {
-    /// 1-based page number.
+    /// 0-based page number.
     pub page: u32,
-    /// 1-based slot number.
+    /// 0-based slot number.
     pub slot: u32,
     pub id: String,
     pub source: String,

--- a/src/commands/page/weight.rs
+++ b/src/commands/page/weight.rs
@@ -67,7 +67,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         setup_repo(&tmp, &state);
 
-        execute_weight(tmp.path(), WeightAddress::Page(1), 2.5).unwrap();
+        execute_weight(tmp.path(), WeightAddress::Page(0), 2.5).unwrap();
 
         let mgr = StateManager::open(tmp.path()).unwrap();
         let files = &mgr.state.photos[0].files;
@@ -86,7 +86,7 @@ mod tests {
 
         execute_weight(
             tmp.path(),
-            WeightAddress::Slots { page: 1, slots: SlotExpr::from_range(1, 2) },
+            WeightAddress::Slots { page: 0, slots: SlotExpr::from_range(0, 1) },
             3.0,
         ).unwrap();
 
@@ -104,7 +104,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         setup_repo(&tmp, &state);
 
-        let err = execute_weight(tmp.path(), WeightAddress::Page(1), 0.0).unwrap_err();
+        let err = execute_weight(tmp.path(), WeightAddress::Page(0), 0.0).unwrap_err();
         assert!(matches!(
             err,
             PageMoveError::Validation(ValidationError::WeightOutOfRange(_))

--- a/src/commands/unplace.rs
+++ b/src/commands/unplace.rs
@@ -12,7 +12,7 @@ use crate::commands::page::{
 /// Remove photos from the layout at the given page:slot address.
 ///
 /// Photos are kept in `state.photos` (they become "unplaced").
-/// Returns the 1-based page numbers that were modified.
+/// Returns the 0-based page numbers that were modified.
 pub fn execute_unplace(
     project_root: &Path,
     page: u32,
@@ -59,8 +59,8 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         setup_repo(&tmp, &state);
 
-        let result = execute_unplace(tmp.path(), 1, SlotExpr::single(2)).unwrap();
-        assert_eq!(result.pages_modified, vec![1]);
+        let result = execute_unplace(tmp.path(), 0, SlotExpr::single(1)).unwrap();
+        assert_eq!(result.pages_modified, vec![0]);
 
         let mgr = StateManager::open(tmp.path()).unwrap();
         let page = &mgr.state.layout[0];
@@ -74,8 +74,8 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         setup_repo(&tmp, &state);
 
-        let result = execute_unplace(tmp.path(), 1, SlotExpr::single(1)).unwrap();
-        assert!(result.pages_deleted.contains(&1));
+        let result = execute_unplace(tmp.path(), 0, SlotExpr::single(0)).unwrap();
+        assert!(result.pages_deleted.contains(&0));
         assert!(result.pages_modified.is_empty());
 
         let mgr = StateManager::open(tmp.path()).unwrap();
@@ -90,11 +90,11 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         setup_repo(&tmp, &state);
 
-        let result = execute_unplace(tmp.path(), 1, SlotExpr::single(5));
+        let result = execute_unplace(tmp.path(), 0, SlotExpr::single(5));
         assert!(matches!(
             result,
             Err(PageMoveError::Validation(ValidationError::SlotNotFound {
-                page: 1,
+                page: 0,
                 slot: 5
             }))
         ));

--- a/src/templates/fotobuch.typ
+++ b/src/templates/fotobuch.typ
@@ -325,7 +325,7 @@
     ]
     #for (i, slot) in cover_data.slots.enumerate() [
       #let photo_id = cover_data.photos.at(i, default: none)
-      #render_slot(0, slot, i + 1, photo_id, photo_ref, photo_weight)
+      #render_slot(0, slot, i, photo_id, photo_ref, photo_weight)
     ]
     // Spine text — reads bottom-to-top; dx = half of front+back = single page width
     #place(top + left, dx: (cover_front_back_w / 2) * 1mm, dy: 0mm, box(
@@ -355,7 +355,7 @@
 
   #for (i, slot) in page_data.slots.enumerate() [
     #let photo_id = page_data.photos.at(i, default: none)
-    #render_slot(page_index, slot, i + 1, photo_id, photo_ref, photo_weight)
+    #render_slot(page_index, slot, i, photo_id, photo_ref, photo_weight)
   ]
 
   #let display_nr = page_index - layout_start + 1


### PR DESCRIPTION
This PR converts the page and slot numbering system throughout the codebase from 1-based to 0-based indexing, making it more consistent with typical programming conventions and internal array indexing.

## Summary
All user-facing page and slot numbers are now 0-based instead of 1-based. This affects command APIs, validation logic, test cases, and template rendering.

## Key Changes

- **Page numbering**: Pages are now numbered starting from 0 instead of 1
  - Updated `page_idx()` helper to work with 0-based page numbers
  - Fixed `execute_move_to()` to use correct page numbering in `NewPageAfter` destination
  - Updated all page move, split, combine, and info commands

- **Slot numbering**: Slots are now numbered starting from 0 instead of 1
  - Modified `resolve_slots()` to handle 0-based slot numbers
  - Updated range resolution logic (open-ended ranges now use 0-based defaults)
  - Removed validation that rejected slot 0 as invalid
  - Updated slot validation to use `>=` instead of `==0 ||` checks

- **Test updates**: All test cases updated to use 0-based numbering
  - Page references in move, swap, split, combine, and info tests
  - Slot references in slot-based operations
  - Test comments updated to reflect new numbering scheme

- **Template changes**: Updated Typst template to use 0-based slot indexing
  - Changed `i + 1` to `i` when passing slot numbers to `render_slot()`

- **Documentation**: Updated docstring comments to reflect 0-based numbering
  - Helper function documentation
  - Return value descriptions in `PageMoveResult` and `SlotInfo`
  - Function parameter documentation

## Implementation Details

The conversion maintains backward compatibility at the internal state level while changing the external API. The `LayoutPage.page` field is still renumbered by `finish()` calls, but user-facing APIs now consistently use 0-based numbering.

https://claude.ai/code/session_011G5nurXbF5nk9VTbcQipNt