### PR TITLE
feat: move and swap slots onto manual-mode pages

### DIFF
--- a/gui/app.rs
+++ b/gui/app.rs
@@ -302,6 +302,9 @@ fn mark_dirty(dirty: &mut [bool], task: &BackgroundTask) {
             left: src_page,
             right: dst_page,
             ..
+        }
+        | BackgroundTask::MoveToManual {
+            src_page, dst_page, ..
         } => {
             for &p in &[*src_page, *dst_page] {
                 if let Some(d) = dirty.get_mut(p) {

--- a/gui/app/input_handler/drag.rs
+++ b/gui/app/input_handler/drag.rs
@@ -22,10 +22,11 @@ pub(super) fn handle_drag_start(interaction: &mut InteractionState, ctx: &egui::
     let drag_source = if let Some(HoveredTarget::Page {
         page,
         slot: Some(slot),
-        ..
+        cursor_mm,
     }) = &interaction.hovered
     {
         let (src_page, src_slot) = (*page, *slot);
+        let cursor_mm_at_drag_start = *cursor_mm;
         let mut src_slots = if interaction.selections.slots.is_selected(src_page, src_slot)
             && interaction.selections.slots.page == Some(src_page)
         {
@@ -39,6 +40,7 @@ pub(super) fn handle_drag_start(interaction: &mut InteractionState, ctx: &egui::
             src_slot,
             src_slots,
             cursor_at_drag_start: cursor,
+            cursor_mm_at_drag_start,
         })
     } else if let Some(HoveredTarget::NavPage(nav_page)) = &interaction.hovered {
         let nav_page = *nav_page;
@@ -111,9 +113,18 @@ pub(super) fn handle_drag_complete(
                     src_page,
                     src_slot,
                     src_slots,
+                    cursor_mm_at_drag_start,
                     ..
                 } => {
-                    complete_slot_drag(data, interaction, cmds, src_page, src_slot, src_slots);
+                    error = complete_slot_drag(
+                        data,
+                        interaction,
+                        cmds,
+                        src_page,
+                        src_slot,
+                        src_slots,
+                        cursor_mm_at_drag_start,
+                    );
                 }
                 DragSource::NavPage {
                     src_page,
@@ -200,6 +211,7 @@ pub(super) fn handle_drag_complete(
     }
 }
 
+/// Returns an error message when the drag is rejected, otherwise `None`.
 pub(super) fn complete_slot_drag(
     data: &DataState,
     interaction: &mut InteractionState,
@@ -207,7 +219,8 @@ pub(super) fn complete_slot_drag(
     src_page: usize,
     src_slot: usize,
     src_slots: Vec<usize>,
-) {
+    cursor_mm_at_drag_start: (f32, f32),
+) -> Option<String> {
     if let Some(at_position) = interaction
         .hovered
         .as_ref()
@@ -218,7 +231,7 @@ pub(super) fn complete_slot_drag(
             src_slots,
             at_position,
         });
-        return;
+        return None;
     }
 
     let src_is_manual = data
@@ -247,12 +260,24 @@ pub(super) fn complete_slot_drag(
         .map(|p| p.mode == PageMode::Manual)
         .unwrap_or(false);
 
-    // Swap is not allowed when either the source or destination page is Manual.
-    if interaction.drag.mode == DragMode::Swap && (src_is_manual || dst_is_manual) {
-        return;
-    }
-
     match (hovered_slot, interaction.drag.mode) {
+        (_, DragMode::Move) if dst_is_manual => {
+            // Drop onto a Manual page: keep each moved slot's size and put the
+            // dragged photo's upper-left where its drag ghost sits.
+            let dst_page = effective_page?;
+            if dst_page == src_page {
+                return None;
+            }
+            let (x_mm, y_mm) =
+                manual_drop_top_left(data, src_page, src_slot, cursor_mm_at_drag_start, cursor_mm);
+            cmds.push(BackgroundTask::MoveToManual {
+                src_page,
+                src_slots,
+                dst_page,
+                x_mm,
+                y_mm,
+            });
+        }
         (Some((dst_page, dst_slot)), DragMode::Swap) => {
             if src_slots.len() == 1 {
                 dispatch_swap(cmds, src_page, src_slots[0], dst_page, dst_slot);
@@ -268,30 +293,6 @@ pub(super) fn complete_slot_drag(
                 });
             }
         }
-        (_, DragMode::Move) if dst_is_manual => {
-            // Drop onto a Manual page: move the first slot and place it at cursor position.
-            if let Some(dst_page) = effective_page
-                && let Some((x_mm, y_mm)) = cursor_mm
-                && src_slots.len() == 1
-            {
-                let slot = src_slots[0];
-                dispatch_move(cmds, src_page, vec![slot], dst_page);
-                // The moved slot lands at index 0 on the dst page (it is the only one, or first).
-                // Use PagePos::Absolute to position it at the drop point.
-                cmds.push(BackgroundTask::PagePos {
-                    page: dst_page,
-                    slot: 0,
-                    mode: PagePosMode::Absolute {
-                        x_mm: x_mm as f64,
-                        y_mm: y_mm as f64,
-                    },
-                    scale: None,
-                });
-            } else if let Some(dst_page) = effective_page {
-                // Multi-slot: just move without repositioning.
-                dispatch_move(cmds, src_page, src_slots, dst_page);
-            }
-        }
         (Some((dst_page, _)), DragMode::Move) => {
             dispatch_move(cmds, src_page, src_slots, dst_page);
         }
@@ -302,6 +303,30 @@ pub(super) fn complete_slot_drag(
         }
         (None, DragMode::Swap) => {}
     }
+    None
+}
+
+/// Upper-left position (in dst-page mm) for the dragged slot when dropping onto a
+/// Manual page: the cursor's drop point minus the grab offset within the slot, so
+/// the slot lands exactly where its drag ghost was shown.
+fn manual_drop_top_left(
+    data: &DataState,
+    src_page: usize,
+    src_slot: usize,
+    cursor_mm_at_drag_start: (f32, f32),
+    drop_cursor_mm: Option<(f32, f32)>,
+) -> (f64, f64) {
+    let (sx, sy) = data
+        .project
+        .layout
+        .get(src_page)
+        .and_then(|p| p.slots.get(src_slot))
+        .map(|s| (s.x_mm, s.y_mm))
+        .unwrap_or((0.0, 0.0));
+    let grab_x = cursor_mm_at_drag_start.0 as f64 - sx;
+    let grab_y = cursor_mm_at_drag_start.1 as f64 - sy;
+    let (cx, cy) = drop_cursor_mm.unwrap_or(cursor_mm_at_drag_start);
+    (cx as f64 - grab_x, cy as f64 - grab_y)
 }
 
 pub(super) fn complete_nav_drag(

--- a/gui/app/input_handler/tests.rs
+++ b/gui/app/input_handler/tests.rs
@@ -8,7 +8,7 @@ use super::*;
 use crate::state::{GuiState, HoveredTarget, SlotSelection};
 
 fn state_with_selection(sel_page: usize, sel_slots: Vec<usize>) -> GuiState {
-    let mut state = GuiState::new(ProjectState::default());
+    let mut state = GuiState::new_for_test(ProjectState::default());
     for (i, &slot) in sel_slots.iter().enumerate() {
         if i == 0 {
             state.interaction.selections.slots = SlotSelection::single(sel_page, slot);
@@ -62,7 +62,7 @@ fn dispatch_swap_ignores_same_slot() {
 }
 
 fn state_with_pool_selection(ids: Vec<&str>) -> GuiState {
-    let mut state = GuiState::new(ProjectState::default());
+    let mut state = GuiState::new_for_test(ProjectState::default());
     for id in &ids {
         state.interaction.selections.photos.toggle(id.to_string());
     }
@@ -121,14 +121,14 @@ fn place_hotkey_emits_place_without_target_when_no_hover() {
 
 #[test]
 fn place_hotkey_no_op_when_selection_empty() {
-    let state = GuiState::new(ProjectState::default());
+    let state = GuiState::new_for_test(ProjectState::default());
     let ids = state.interaction.selections.photos.ids();
     assert!(ids.is_empty());
 }
 
 #[test]
 fn pool_drag_complete_emits_place_on_hovered_page() {
-    let mut state = GuiState::new(ProjectState::default());
+    let mut state = GuiState::new_for_test(ProjectState::default());
     state.interaction.hovered = Some(HoveredTarget::Page {
         page: 1,
         slot: None,
@@ -145,7 +145,7 @@ fn pool_drag_complete_emits_place_on_hovered_page() {
 
 #[test]
 fn pool_drag_complete_cancels_without_hovered_page() {
-    let mut state = GuiState::new(ProjectState::default());
+    let mut state = GuiState::new_for_test(ProjectState::default());
     state.interaction.hovered = None;
     let mut cmds = Vec::new();
     complete_pool_drag(&mut state.interaction, &mut cmds, vec!["a.jpg".into()]);
@@ -158,13 +158,15 @@ fn default_data() -> crate::state::DataState {
         derived: crate::state::DerivedState::rebuild(&ProjectState::default()),
         pages: crate::state::PageCache::new(0),
         thumbs: Default::default(),
-        timings: Default::default(),
+        vault_path: std::path::PathBuf::new(),
+        projects: Vec::new(),
+        history: Vec::new(),
     }
 }
 
 #[test]
 fn nav_drag_complete_emits_page_swap() {
-    let mut state = GuiState::new(ProjectState::default());
+    let mut state = GuiState::new_for_test(ProjectState::default());
     state.interaction.hovered = Some(HoveredTarget::NavPage(2));
     let mut cmds = Vec::new();
     complete_nav_drag(&default_data(), &mut state.interaction, &mut cmds, 0);
@@ -178,7 +180,7 @@ fn nav_drag_complete_emits_page_swap() {
 
 #[test]
 fn nav_drag_complete_noop_when_same_page() {
-    let mut state = GuiState::new(ProjectState::default());
+    let mut state = GuiState::new_for_test(ProjectState::default());
     state.interaction.hovered = Some(HoveredTarget::NavPage(1));
     let mut cmds = Vec::new();
     complete_nav_drag(&default_data(), &mut state.interaction, &mut cmds, 1);
@@ -214,6 +216,7 @@ fn drop_on_new_page_slot_emits_move_to_new_page() {
         1,
         1,
         vec![1, 2],
+        (0.0, 0.0),
     );
     assert_eq!(cmds.len(), 1);
     let BackgroundTask::MoveToNewPage {
@@ -231,7 +234,7 @@ fn drop_on_new_page_slot_emits_move_to_new_page() {
 
 #[test]
 fn drop_on_new_page_slot_at_zero_inserts_before_first_page() {
-    let mut state = GuiState::new(ProjectState::default());
+    let mut state = GuiState::new_for_test(ProjectState::default());
     state.interaction.hovered = Some(HoveredTarget::NewPageSlot { at_position: 0 });
     let mut cmds = Vec::new();
     complete_slot_drag(
@@ -241,6 +244,7 @@ fn drop_on_new_page_slot_at_zero_inserts_before_first_page() {
         0,
         0,
         vec![0],
+        (0.0, 0.0),
     );
     assert_eq!(cmds.len(), 1);
     let BackgroundTask::MoveToNewPage { at_position, .. } = cmds.iter().next().unwrap() else {
@@ -275,7 +279,9 @@ fn data_with_layout(layout: Vec<fotobuch::dto_models::LayoutPage>) -> crate::sta
         pages: crate::state::PageCache::new(project.layout.len()),
         project,
         thumbs: Default::default(),
-        timings: Default::default(),
+        vault_path: std::path::PathBuf::new(),
+        projects: Vec::new(),
+        history: Vec::new(),
     }
 }
 
@@ -300,6 +306,7 @@ fn swap_range_uses_full_selection_when_dragged_slot_selected() {
         0,
         1,
         vec![1, 2, 3],
+        (0.0, 0.0),
     );
     assert_eq!(cmds.len(), 1);
     let BackgroundTask::SwapRange {
@@ -335,6 +342,7 @@ fn swap_range_noop_when_target_too_narrow() {
         0,
         0,
         vec![0, 1, 2],
+        (0.0, 0.0),
     );
     assert!(cmds.is_empty(), "overrun → no command emitted");
 }
@@ -353,7 +361,15 @@ fn swap_range_noop_when_selection_not_contiguous() {
         cursor_mm: (0.0, 0.0),
     });
     let mut cmds = Vec::new();
-    complete_slot_drag(&data, &mut state.interaction, &mut cmds, 0, 0, vec![0, 2]);
+    complete_slot_drag(
+        &data,
+        &mut state.interaction,
+        &mut cmds,
+        0,
+        0,
+        vec![0, 2],
+        (0.0, 0.0),
+    );
     assert!(cmds.is_empty(), "non-contiguous selection → no command");
 }
 
@@ -371,7 +387,15 @@ fn swap_falls_back_to_single_when_selection_is_one() {
         cursor_mm: (0.0, 0.0),
     });
     let mut cmds = Vec::new();
-    complete_slot_drag(&data, &mut state.interaction, &mut cmds, 0, 1, vec![1]);
+    complete_slot_drag(
+        &data,
+        &mut state.interaction,
+        &mut cmds,
+        0,
+        1,
+        vec![1],
+        (0.0, 0.0),
+    );
     assert_eq!(cmds.len(), 1);
     assert!(
         matches!(cmds.iter().next().unwrap(), BackgroundTask::Swap { .. }),
@@ -401,7 +425,7 @@ fn handle_delete_emits_unplace_with_selection_slots() {
 
 #[test]
 fn handle_delete_emits_delete_page_when_only_page_hovered() {
-    let state = GuiState::new(ProjectState::default());
+    let state = GuiState::new_for_test(ProjectState::default());
     let target = HoveredTarget::Page {
         page: 4,
         slot: None,
@@ -449,7 +473,7 @@ fn handle_delete_noop_on_cover_when_active() {
 #[test]
 fn rebuild_selection_matches_selected_page() {
     use crate::app::rebuild::{PagesForRebuild, selected_pages_for_rebuild};
-    let mut interaction = GuiState::new(ProjectState::default()).interaction;
+    let mut interaction = GuiState::new_for_test(ProjectState::default()).interaction;
     interaction.selections.slots = SlotSelection::single(5, 0);
     assert!(
         matches!(selected_pages_for_rebuild(&interaction), PagesForRebuild::Selected(p) if p == vec![5])
@@ -459,9 +483,83 @@ fn rebuild_selection_matches_selected_page() {
 #[test]
 fn rebuild_without_selection_opens_confirm_path() {
     use crate::app::rebuild::{PagesForRebuild, selected_pages_for_rebuild};
-    let interaction = GuiState::new(ProjectState::default()).interaction;
+    let interaction = GuiState::new_for_test(ProjectState::default()).interaction;
     assert!(matches!(
         selected_pages_for_rebuild(&interaction),
         PagesForRebuild::None
     ));
+}
+
+fn manual_layout_page(page: usize, n_slots: usize) -> fotobuch::dto_models::LayoutPage {
+    let mut p = layout_page_with_slots(page, n_slots);
+    p.mode = fotobuch::dto_models::PageMode::Manual;
+    p
+}
+
+#[test]
+fn move_onto_manual_page_emits_move_to_manual_at_ghost_position() {
+    // Slot 0 of the source sits at (0,0); the user grabbed it 10mm/20mm inside.
+    // Dropping with the cursor at (60,70) on the manual page must land the
+    // slot's upper-left at (60-10, 70-20) = (50, 50).
+    let mut state = state_with_selection(0, vec![0]);
+    state.interaction.drag.mode = crate::state::DragMode::Move;
+    let data = data_with_layout(vec![layout_page_with_slots(0, 1), manual_layout_page(1, 1)]);
+    state.interaction.hovered = Some(HoveredTarget::Page {
+        page: 1,
+        slot: Some(0),
+        cursor_mm: (60.0, 70.0),
+    });
+    let mut cmds = Vec::new();
+    complete_slot_drag(
+        &data,
+        &mut state.interaction,
+        &mut cmds,
+        0,
+        0,
+        vec![0],
+        (10.0, 20.0),
+    );
+    assert_eq!(cmds.len(), 1);
+    let BackgroundTask::MoveToManual {
+        src_page,
+        dst_page,
+        x_mm,
+        y_mm,
+        ..
+    } = cmds.first().unwrap()
+    else {
+        panic!("expected MoveToManual");
+    };
+    assert_eq!(*src_page, 0);
+    assert_eq!(*dst_page, 1);
+    assert!((*x_mm - 50.0).abs() < 1e-6);
+    assert!((*y_mm - 50.0).abs() < 1e-6);
+}
+
+#[test]
+fn swap_onto_manual_page_is_allowed() {
+    let mut state = state_with_selection(0, vec![0]);
+    state.interaction.drag.mode = crate::state::DragMode::Swap;
+    let data = data_with_layout(vec![layout_page_with_slots(0, 1), manual_layout_page(1, 2)]);
+    state.interaction.hovered = Some(HoveredTarget::Page {
+        page: 1,
+        slot: Some(1),
+        cursor_mm: (0.0, 0.0),
+    });
+    let mut cmds = Vec::new();
+    complete_slot_drag(
+        &data,
+        &mut state.interaction,
+        &mut cmds,
+        0,
+        0,
+        vec![0],
+        (0.0, 0.0),
+    );
+    assert_eq!(
+        cmds.len(),
+        1,
+        "swap into a manual page should now be allowed"
+    );
+    assert!(matches!(cmds.first().unwrap(), BackgroundTask::Swap { .. }));
 }

--- a/gui/app/rebuild.rs
+++ b/gui/app/rebuild.rs
@@ -24,7 +24,7 @@ mod tests {
     use crate::state::{GuiState, SlotSelection};
 
     fn make_interaction() -> crate::state::InteractionState {
-        GuiState::new(ProjectState::default()).interaction
+        GuiState::new_for_test(ProjectState::default()).interaction
     }
 
     #[test]

--- a/gui/app/widgets/central_panel/draw_page/manual.rs
+++ b/gui/app/widgets/central_panel/draw_page/manual.rs
@@ -1,4 +1,4 @@
-use crate::state::{ActiveDrag, DataState, DragMode, DragSource, InteractionState};
+use crate::state::{ActiveDrag, DataState, DragSource, InteractionState};
 
 use super::super::super::geometry::{self, PageDimensions};
 use super::super::manual_resize;
@@ -20,10 +20,9 @@ pub(super) fn draw_manual_handles_and_overlay(
     let cursor = ui.input(|i| i.pointer.hover_pos()).unwrap_or_default();
     let rmb_pressed = ui.input(|i| i.pointer.secondary_pressed());
 
-    if rmb_pressed
-        && interaction.drag.mode == DragMode::Move
-        && matches!(interaction.drag.active, ActiveDrag::Idle)
-    {
+    // Free-position move/resize on a manual page works in any drag mode: the
+    // Swap/Move toggle only governs slot drags that start on Auto pages.
+    if rmb_pressed && matches!(interaction.drag.active, ActiveDrag::Idle) {
         try_start_manual_drag(
             interaction,
             layout_page,

--- a/gui/background.rs
+++ b/gui/background.rs
@@ -245,6 +245,15 @@ fn dispatch_world_task(task: BackgroundTask, rctx: &mut RenderCtx<'_>) {
         } => {
             commands::run_move_to_new_page(src_page, src_slots, at_position, rctx);
         }
+        BackgroundTask::MoveToManual {
+            src_page,
+            src_slots,
+            dst_page,
+            x_mm,
+            y_mm,
+        } => {
+            commands::run_move_to_manual(src_page, src_slots, dst_page, x_mm, y_mm, rctx);
+        }
         BackgroundTask::SwapRange {
             src_page,
             src_slots,

--- a/gui/background/commands/page.rs
+++ b/gui/background/commands/page.rs
@@ -131,6 +131,28 @@ pub fn run_move_to_new_page(
     run_page_command(cmd, rctx);
 }
 
+pub fn run_move_to_manual(
+    src_page: usize,
+    src_slots: Vec<usize>,
+    dst_page: usize,
+    x_mm: f64,
+    y_mm: f64,
+    rctx: &mut crate::background::RenderCtx<'_>,
+) {
+    let cmd = PageMoveCmd::Move {
+        src: Src::Slots {
+            page: src_page as u32,
+            slots: SlotExpr::from_list(src_slots.iter().map(|&s| s as u32).collect()),
+        },
+        dst: DstMove::ManualAt {
+            page: dst_page as u32,
+            x_mm,
+            y_mm,
+        },
+    };
+    run_page_command(cmd, rctx);
+}
+
 pub fn run_swap_range(
     src_page: usize,
     src_slots: Vec<usize>,

--- a/gui/state.rs
+++ b/gui/state.rs
@@ -160,6 +160,13 @@ impl GuiState {
             },
         }
     }
+
+    /// Test-only constructor: a `GuiState` for `project` with an empty vault,
+    /// no sibling projects, and the welcome modal hidden.
+    #[cfg(test)]
+    pub fn new_for_test(project: ProjectState) -> Self {
+        Self::new(project, PathBuf::new(), Vec::new(), false)
+    }
 }
 
 /// Uploads a rendered page (full + thumb) into the egui texture cache and clears its dirty flag.
@@ -253,7 +260,7 @@ mod tests {
 
     #[test]
     fn resize_page_vecs_also_resizes_thumb_vec() {
-        let mut state = GuiState::new(minimal_project());
+        let mut state = GuiState::new_for_test(minimal_project());
         resize_page_vecs(&mut state, 4);
         assert_eq!(state.data.pages.thumb_textures.len(), 4);
         resize_page_vecs(&mut state, 2);
@@ -271,7 +278,7 @@ mod tests {
 
     #[test]
     fn resize_page_vecs_grows_and_shrinks() {
-        let mut state = GuiState::new(minimal_project());
+        let mut state = GuiState::new_for_test(minimal_project());
         resize_page_vecs(&mut state, 3);
         assert_eq!(state.data.pages.textures.len(), 3);
         assert_eq!(state.data.pages.dirty.len(), 3);

--- a/gui/state/drag.rs
+++ b/gui/state/drag.rs
@@ -32,6 +32,9 @@ pub enum DragSource {
         /// Full slot selection captured at drag-start (may be multi-slot).
         src_slots: Vec<usize>,
         cursor_at_drag_start: egui::Pos2,
+        /// Cursor position in source-page mm at drag-start, used to keep the
+        /// grab offset when dropping onto a Manual page.
+        cursor_mm_at_drag_start: (f32, f32),
     },
     /// Right-mouse drag from a page thumbnail in the nav panel.
     NavPage {

--- a/gui/task.rs
+++ b/gui/task.rs
@@ -50,6 +50,15 @@ pub enum BackgroundTask {
         src_slots: Vec<usize>,
         at_position: usize,
     },
+    /// Move slots onto a Manual page, placing the dragged photo's upper-left at
+    /// `(x_mm, y_mm)` while keeping each moved slot's size.
+    MoveToManual {
+        src_page: usize,
+        src_slots: Vec<usize>,
+        dst_page: usize,
+        x_mm: f64,
+        y_mm: f64,
+    },
     SwapRange {
         src_page: usize,
         src_slots: Vec<usize>,

--- a/src/commands/page/move_cmd.rs
+++ b/src/commands/page/move_cmd.rs
@@ -3,12 +3,13 @@
 use std::path::Path;
 
 use crate::commands::CommandOutput;
-use crate::dto_models::{LayoutPage, PageMode};
+use crate::dto_models::{LayoutPage, PageMode, Slot};
 use crate::state_manager::StateManager;
 
 use super::helpers::{
     collect_dst_swap_photos_with_indices, collect_src_photos, collect_src_photos_with_indices,
-    delete_empty_pages, format_pages_list, format_src_desc, page_idx, remove_slots, resolve_slots,
+    delete_empty_pages, format_pages_list, format_src_desc, page_idx, photos_at_slots,
+    remove_slots, resolve_slots,
 };
 use super::types::{
     DstMove, DstSwap, PageMoveCmd, PageMoveError, PageMoveResult, Src, ValidationError,
@@ -25,11 +26,19 @@ pub fn execute_move(
     }
 }
 
+/// Cascade offset between consecutive slots when several photos are dropped onto
+/// a Manual page in one gesture, so they don't perfectly overlap.
+const MANUAL_DROP_CASCADE_MM: f64 = 10.0;
+
 fn execute_move_to(
     project_root: &Path,
     src: Src,
     dst: DstMove,
 ) -> Result<CommandOutput<PageMoveResult>, PageMoveError> {
+    if let DstMove::ManualAt { page, x_mm, y_mm } = dst {
+        return execute_move_to_manual(project_root, src, page, x_mm, y_mm);
+    }
+
     if let Src::Slots { page, slots: _ } = &src
         && let DstMove::Page(dst_page) = &dst
         && *page == *dst_page
@@ -148,6 +157,7 @@ fn execute_move_to(
             (new_idx, Some(new_page_num as u32))
         }
         DstMove::Unplace => unreachable!("Unplace handled above"),
+        DstMove::ManualAt { .. } => unreachable!("ManualAt handled above"),
     };
 
     // For Slots variant: remove photos from src and add to dst.
@@ -238,6 +248,150 @@ fn execute_move_to(
     })
 }
 
+/// Move the source slots onto a Manual-mode page, creating a positioned slot for
+/// each moved photo. New slots keep the size of their source slot; the first is
+/// placed with its top-left at `(x_mm, y_mm)`, further ones cascade.
+fn execute_move_to_manual(
+    project_root: &Path,
+    src: Src,
+    dst_page: u32,
+    x_mm: f64,
+    y_mm: f64,
+) -> Result<CommandOutput<PageMoveResult>, PageMoveError> {
+    let Src::Slots {
+        page: src_page,
+        slots,
+    } = &src
+    else {
+        // Whole-page moves onto a manual page are not supported via this path.
+        return Err(ValidationError::PageNotManual(dst_page).into());
+    };
+    let src_page = *src_page;
+
+    let mut mgr = StateManager::open(project_root)?;
+
+    let dst_idx = page_idx(dst_page, &mgr.state.layout)?;
+    if mgr.state.layout[dst_idx].mode != PageMode::Manual {
+        return Err(ValidationError::PageNotManual(dst_page).into());
+    }
+    if src_page == dst_page {
+        // Same page → a free reposition, handled by `page pos`, not here.
+        let changed_state = mgr.finish("")?;
+        return Ok(CommandOutput {
+            result: PageMoveResult {
+                pages_modified: vec![],
+                pages_inserted: vec![],
+                pages_deleted: vec![],
+            },
+            changed_state,
+        });
+    }
+
+    let src_idx = page_idx(src_page, &mgr.state.layout)?;
+    let mut slot_indices = resolve_slots(src_page, slots, &mgr.state.layout)?;
+    slot_indices.sort_unstable();
+
+    // Snapshot each moved photo together with the size of its source slot.
+    let mut moved: Vec<(String, f64, f64)> = Vec::with_capacity(slot_indices.len());
+    for &i in &slot_indices {
+        let photo = photos_at_slots(&mgr.state.layout, src_idx, &[i])?.remove(0);
+        let slot = mgr.state.layout[src_idx].slots.get(i);
+        let (w, h) = match slot {
+            Some(s) => (s.width_mm, s.height_mm),
+            None => default_manual_slot_size(&mgr.state, dst_idx),
+        };
+        moved.push((photo, w, h));
+    }
+
+    // Remove from src (descending so indices stay valid). Drop the slot only on a
+    // manual source; Auto pages recompute their slots on the next build.
+    let src_is_manual = mgr.state.layout[src_idx].mode == PageMode::Manual;
+    let mut desc = slot_indices.clone();
+    desc.sort_unstable_by(|a, b| b.cmp(a));
+    for &i in &desc {
+        mgr.state.layout[src_idx].photos.remove(i);
+        if src_is_manual && i < mgr.state.layout[src_idx].slots.len() {
+            mgr.state.layout[src_idx].slots.remove(i);
+        }
+    }
+
+    // Append photos and matching positioned slots to the manual destination.
+    for (n, (photo, w, h)) in moved.into_iter().enumerate() {
+        let offset = MANUAL_DROP_CASCADE_MM * n as f64;
+        mgr.state.layout[dst_idx].photos.push(photo);
+        mgr.state.layout[dst_idx].slots.push(Slot {
+            x_mm: x_mm + offset,
+            y_mm: y_mm + offset,
+            width_mm: w,
+            height_mm: h,
+        });
+    }
+
+    let dst_page_num = mgr.state.layout[dst_idx].page as u32;
+    let deleted = delete_empty_pages(&mut mgr.state.layout);
+    let mut modified = vec![src_page, dst_page_num];
+    modified.retain(|p| !deleted.contains(p));
+    modified.sort_unstable();
+    modified.dedup();
+
+    let changed_state = mgr.finish(&format!(
+        "page move: slots from page {src_page} -> manual page {dst_page_num}"
+    ))?;
+    Ok(CommandOutput {
+        result: PageMoveResult {
+            pages_modified: modified,
+            pages_inserted: vec![],
+            pages_deleted: deleted,
+        },
+        changed_state,
+    })
+}
+
+/// Fallback slot size when a source slot has no computed geometry yet
+/// (e.g. an Auto page that was never built): 30 % of the destination page.
+fn default_manual_slot_size(state: &crate::dto_models::ProjectState, dst_idx: usize) -> (f64, f64) {
+    let (pw, ph) = state.page_dimensions_mm(dst_idx);
+    (pw * 0.3, ph * 0.3)
+}
+
+/// Pixel dimensions of a photo by id, looked up across all photo groups.
+fn photo_pixel_size(state: &crate::dto_models::ProjectState, id: &str) -> Option<(u32, u32)> {
+    state
+        .photos
+        .iter()
+        .flat_map(|g| g.files.iter())
+        .find(|f| f.id == id)
+        .map(|f| (f.width_px, f.height_px))
+}
+
+/// On a Manual `page_idx`, set the height of each receiving slot in
+/// `[start, start + count)` to `width * photo_height / photo_width`, keeping the
+/// slot's top-left and width. No-op on Auto pages (their slots are recomputed).
+fn adapt_manual_slot_ratios(
+    state: &mut crate::dto_models::ProjectState,
+    page_idx: usize,
+    start: usize,
+    count: usize,
+) {
+    if state.layout[page_idx].mode != PageMode::Manual {
+        return;
+    }
+    for i in start..start + count {
+        let Some(photo_id) = state.layout[page_idx].photos.get(i).cloned() else {
+            continue;
+        };
+        if state.layout[page_idx].slots.get(i).is_none() {
+            continue;
+        }
+        if let Some((w_px, h_px)) = photo_pixel_size(state, &photo_id)
+            && w_px > 0
+        {
+            let slot = &mut state.layout[page_idx].slots[i];
+            slot.height_mm = slot.width_mm * (h_px as f64 / w_px as f64);
+        }
+    }
+}
+
 fn execute_swap(
     project_root: &Path,
     left: Src,
@@ -310,6 +464,18 @@ fn execute_swap(
             photos: &right_photos,
         },
     );
+
+    // On a Manual page the receiving slots keep their position and width, but their
+    // height adapts to the incoming photo's aspect ratio (cross-page swaps only;
+    // same-page swaps cannot target a Manual page from the GUI).
+    if left_page_idx != right_page_idx {
+        let left_recv = right_photos.len();
+        let right_recv = left_photos.len();
+        let left_start = left_slot_indices.iter().min().copied().unwrap_or(0);
+        let right_start = right_slot_indices.iter().min().copied().unwrap_or(0);
+        adapt_manual_slot_ratios(&mut mgr.state, left_page_idx, left_start, left_recv);
+        adapt_manual_slot_ratios(&mut mgr.state, right_page_idx, right_start, right_recv);
+    }
 
     let mut modified_pages = vec![
         mgr.state.layout[left_page_idx].page as u32,
@@ -782,6 +948,101 @@ mod tests {
         let mgr = StateManager::open(tmp.path()).unwrap();
         assert_eq!(mgr.state.layout.len(), 2);
         assert!(mgr.state.layout[1].photos.contains(&"a.jpg".to_owned()));
+        mgr.finish("test: noop").unwrap();
+    }
+
+    #[test]
+    fn move_slot_into_manual_page_creates_positioned_slot() {
+        use super::super::mode::execute_mode;
+        use crate::dto_models::PageMode;
+
+        let state = make_state_with_layout(vec![vec!["p0.jpg", "p1.jpg"], vec!["p2.jpg"]]);
+        let tmp = TempDir::new().unwrap();
+        setup_repo(&tmp, &state);
+        // Page 1 becomes Manual.
+        execute_mode(tmp.path(), PagesExpr::single(1), PageMode::Manual).unwrap();
+
+        let cmd = PageMoveCmd::Move {
+            src: Src::Slots {
+                page: 0,
+                slots: SlotExpr::single(0),
+            },
+            dst: DstMove::ManualAt {
+                page: 1,
+                x_mm: 50.0,
+                y_mm: 60.0,
+            },
+        };
+        execute_move(tmp.path(), cmd).unwrap();
+
+        let mgr = StateManager::open(tmp.path()).unwrap();
+        let dst = &mgr.state.layout[1];
+        // Manual page now holds both photos with matching slot counts.
+        assert_eq!(dst.photos, vec!["p2.jpg", "p0.jpg"]);
+        assert_eq!(dst.slots.len(), dst.photos.len());
+        // New slot keeps the source slot size (fixture: 100 x 80) at the drop point.
+        let new = dst.slots.last().unwrap();
+        assert_eq!((new.x_mm, new.y_mm), (50.0, 60.0));
+        assert_eq!((new.width_mm, new.height_mm), (100.0, 80.0));
+        // Source page lost the moved photo.
+        assert_eq!(mgr.state.layout[0].photos, vec!["p1.jpg"]);
+        mgr.finish("test: noop").unwrap();
+    }
+
+    #[test]
+    fn move_into_non_manual_page_is_rejected() {
+        let state = make_state_with_layout(vec![vec!["p0.jpg", "p1.jpg"], vec!["p2.jpg"]]);
+        let tmp = TempDir::new().unwrap();
+        setup_repo(&tmp, &state);
+
+        let cmd = PageMoveCmd::Move {
+            src: Src::Slots {
+                page: 0,
+                slots: SlotExpr::single(0),
+            },
+            dst: DstMove::ManualAt {
+                page: 1,
+                x_mm: 0.0,
+                y_mm: 0.0,
+            },
+        };
+        let err = execute_move(tmp.path(), cmd).unwrap_err();
+        assert!(matches!(
+            err,
+            PageMoveError::Validation(ValidationError::PageNotManual(1))
+        ));
+    }
+
+    #[test]
+    fn swap_into_manual_page_adapts_slot_height_to_photo_ratio() {
+        use super::super::mode::execute_mode;
+        use super::super::types::DstSwap;
+        use crate::dto_models::PageMode;
+
+        // Fixture photos are 4000 x 3000 (4:3).
+        let state = make_state_with_layout(vec![vec!["p0.jpg"], vec!["p1.jpg"]]);
+        let tmp = TempDir::new().unwrap();
+        setup_repo(&tmp, &state);
+        execute_mode(tmp.path(), PagesExpr::single(1), PageMode::Manual).unwrap();
+
+        let cmd = PageMoveCmd::Swap {
+            left: Src::Slots {
+                page: 0,
+                slots: SlotExpr::single(0),
+            },
+            right: DstSwap::Slots {
+                page: 1,
+                slots: SlotExpr::single(0),
+            },
+        };
+        execute_move(tmp.path(), cmd).unwrap();
+
+        let mgr = StateManager::open(tmp.path()).unwrap();
+        let manual_slot = &mgr.state.layout[1].slots[0];
+        // Width kept (100), height now matches the incoming photo's ratio: 100 * 3/4 = 75.
+        assert_eq!(manual_slot.width_mm, 100.0);
+        assert!((manual_slot.height_mm - 75.0).abs() < 1e-9);
+        assert_eq!(mgr.state.layout[1].photos, vec!["p0.jpg"]);
         mgr.finish("test: noop").unwrap();
     }
 

--- a/src/commands/page/types.rs
+++ b/src/commands/page/types.rs
@@ -106,6 +106,10 @@ pub enum DstMove {
     /// `index = layout.len()` is allowed (append). `index = 0` inserts
     /// before the first existing page.
     NewPageAt(u32),
+    /// Move the source slots onto a Manual-mode page, creating a positioned slot
+    /// for each moved photo. Each new slot keeps the size of its source slot; the
+    /// first lands with its top-left at `(x_mm, y_mm)`, further ones cascade.
+    ManualAt { page: u32, x_mm: f64, y_mm: f64 },
     /// Unplace the source photos (and delete the page if the source is whole pages).
     Unplace,
 }


### PR DESCRIPTION
Fixes #30.

Moving/swapping a slot onto a Manual-mode page previously didn't work (a moved photo got no matching slot, and swaps were rejected in the GUI). This makes both work with sensible, defined geometry, and also fixes free-move on manual pages in Swap mode.

## Changes

**`fix(gui): enable manual free-move/resize in any drag mode`**
- `manual.rs` only started the free-position drag in Move mode, so on a Manual page *every* interaction was blocked while in Swap mode. The Swap/Move toggle only governs slot drags that start on Auto pages, so the gate is removed.

**`feat(page): move and swap slots onto manual-mode pages`** (lib)
- New `DstMove::ManualAt { page, x_mm, y_mm }`: moves the source slots onto a Manual page and creates a positioned slot for each. Every new slot **keeps its source slot's size**; the first lands with its top-left at the given point, further ones cascade.
- Swapping a photo into a Manual slot now **keeps the slot's top-left and width and adapts its height** to the incoming photo's aspect ratio.
- +3 unit tests.

**`feat(gui): drop slots from auto pages onto manual pages`**
- Wires the drag handler to the new library support. Move mode places the slot with the dragged photo's upper-left at the drag-ghost position (grab offset captured in mm at drag-start); Swap mode swaps with the hovered Manual slot instead of being rejected.
- +2 tests.

## Notes
- Tests: lib 20 pass (3 new), gui 26 pass (2 new); `cargo fmt` applied; clippy clean for the touched production code.
- Commit 3 also repairs the **gui test build**, which was already broken on the base branch (the test helpers no longer matched the refactored `GuiState::new`/`DataState`). This was needed to run the new gui tests; verified pre-existing via a stash check.
- Multi-slot manual drops: the single dragged photo is placed exactly; a multi-selection cascades from the drop point (no photos are dropped).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wsx8WiTGKCPpddR6mSqEbP)_