### PR TITLE
feat: allow user-defined base config in NewConfig

### DIFF
--- a/cli/cli/project.rs
+++ b/cli/cli/project.rs
@@ -59,6 +59,7 @@ pub fn handle(command: ProjectSubcommand) -> Result<()> {
                 spine_grow_per_10_pages_mm,
                 spine_mm,
                 margin_mm,
+                base_config: None,
             };
 
             let output = commands::project_new(parent, &config)?;

--- a/gui/app/widgets/new_project_dialog.rs
+++ b/gui/app/widgets/new_project_dialog.rs
@@ -1,6 +1,7 @@
 use crate::state::{InteractionState, NewProjectDialogState};
 use crate::task::BackgroundTask;
 use fotobuch::commands::project::new::{NewConfig, validate_project_name};
+use fotobuch::dto_models::{PreviewConfig, ProjectConfig};
 
 pub fn show(
     ctx: &egui::Context,
@@ -115,6 +116,18 @@ fn parse_config(s: &NewProjectDialogState) -> Option<NewConfig> {
         (None, None)
     };
 
+    // Preview overlays look cluttered in the GUI, so disable them by default.
+    let base_config = ProjectConfig {
+        preview: PreviewConfig {
+            show_slot_info: false,
+            show_preview_watermark: false,
+            show_borders: false,
+            show_filenames: false,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
     Some(NewConfig {
         name: s.name.clone(),
         width_mm,
@@ -127,5 +140,6 @@ fn parse_config(s: &NewProjectDialogState) -> Option<NewConfig> {
         spine_grow_per_10_pages_mm,
         spine_mm,
         margin_mm,
+        base_config: Some(base_config),
     })
 }

--- a/src/commands/project/new.rs
+++ b/src/commands/project/new.rs
@@ -43,6 +43,10 @@ pub struct NewConfig {
     pub spine_mm: Option<f64>,
     /// Inner margin in millimeters
     pub margin_mm: f64,
+    /// Optional base config used as starting point. The dimension, cover and
+    /// title fields below are overwritten on top of it. If `None`, defaults
+    /// are used.
+    pub base_config: Option<crate::dto_models::ProjectConfig>,
 }
 
 /// Result of project creation
@@ -309,6 +313,7 @@ mod tests {
             spine_grow_per_10_pages_mm: None,
             spine_mm: None,
             margin_mm: 0.0,
+            base_config: None,
         };
 
         let result = project_new(temp_dir.path(), &config).unwrap();
@@ -348,6 +353,7 @@ mod tests {
             spine_grow_per_10_pages_mm: None,
             spine_mm: None,
             margin_mm: 0.0,
+            base_config: None,
         };
 
         let result = project_new(temp_dir.path(), &config).unwrap();
@@ -373,6 +379,7 @@ mod tests {
             spine_grow_per_10_pages_mm: None,
             spine_mm: None,
             margin_mm: 0.0,
+            base_config: None,
         };
 
         let result = project_new(temp_dir.path(), &config).unwrap();
@@ -397,6 +404,7 @@ mod tests {
             spine_grow_per_10_pages_mm: None,
             spine_mm: None,
             margin_mm: 0.0,
+            base_config: None,
         };
 
         let result = project_new(temp_dir.path(), &config);
@@ -418,6 +426,7 @@ mod tests {
             spine_grow_per_10_pages_mm: None,
             spine_mm: None,
             margin_mm: 0.0,
+            base_config: None,
         };
 
         // Create first project

--- a/src/commands/project/new/yaml.rs
+++ b/src/commands/project/new/yaml.rs
@@ -4,15 +4,16 @@ use anyhow::{Context, Result};
 use std::fs;
 use std::path::Path;
 
-use crate::dto_models::{
-    BookConfig, BookLayoutSolverConfig, CoverConfig, GaConfig, PreviewConfig, ProjectConfig,
-    ProjectState, SpineConfig,
-};
+use crate::dto_models::{BookConfig, CoverConfig, ProjectConfig, ProjectState, SpineConfig};
 use tracing::warn;
 
 use super::NewConfig;
 
 /// Generate default project state from a `NewConfig`.
+///
+/// If `config.base_config` is set it is used as the starting point; the
+/// dimension, cover and title fields from `NewConfig` are then overwritten on
+/// top of it. Otherwise defaults are used.
 pub fn generate_default_state(config: &NewConfig) -> ProjectState {
     let NewConfig {
         name,
@@ -25,8 +26,11 @@ pub fn generate_default_state(config: &NewConfig) -> ProjectState {
         spine_grow_per_10_pages_mm,
         spine_mm,
         margin_mm,
+        base_config,
         ..
     } = config;
+
+    let base = base_config.clone().unwrap_or_default();
 
     let cover = if *with_cover {
         let cw = cover_width_mm.unwrap_or_else(|| {
@@ -71,15 +75,10 @@ pub fn generate_default_state(config: &NewConfig) -> ProjectState {
                 page_height_mm: *height_mm,
                 bleed_mm: *bleed_mm,
                 margin_mm: *margin_mm,
-                gap_mm: 5.0,
-                bleed_threshold_mm: 3.0,
-                dpi: 300.0,
                 cover,
-                appendix: Default::default(),
+                ..base.book
             },
-            page_layout_solver: GaConfig::default(),
-            preview: PreviewConfig::default(),
-            book_layout_solver: BookLayoutSolverConfig::default(),
+            ..base
         },
         photos: Vec::new(),
         layout: Vec::new(),
@@ -115,6 +114,7 @@ mod tests {
             spine_grow_per_10_pages_mm: None,
             spine_mm: None,
             margin_mm: 0.0,
+            base_config: None,
         }
     }
 
@@ -128,6 +128,52 @@ mod tests {
         assert!(!state.config.book.cover.active);
         assert!(state.photos.is_empty());
         assert!(state.layout.is_empty());
+    }
+
+    #[test]
+    fn test_base_config_preserves_non_dimension_fields() {
+        use crate::dto_models::{BookConfig, PreviewConfig, ProjectConfig};
+
+        let base = ProjectConfig {
+            book: BookConfig {
+                dpi: 150.0, // a field that should survive untouched
+                ..Default::default()
+            },
+            preview: PreviewConfig {
+                show_slot_info: false,
+                show_preview_watermark: false,
+                show_borders: false,
+                show_filenames: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let config = NewConfig {
+            width_mm: 100.0,
+            base_config: Some(base),
+            ..test_config()
+        };
+
+        let state = generate_default_state(&config);
+
+        // Dimensions from NewConfig overwrite the base.
+        assert_eq!(state.config.book.page_width_mm, 100.0);
+        // Non-dimension book and preview fields come from the base.
+        assert_eq!(state.config.book.dpi, 150.0);
+        assert!(!state.config.preview.show_slot_info);
+        assert!(!state.config.preview.show_preview_watermark);
+        assert!(!state.config.preview.show_borders);
+        assert!(!state.config.preview.show_filenames);
+    }
+
+    #[test]
+    fn test_default_base_config_uses_defaults() {
+        let state = generate_default_state(&test_config());
+
+        assert_eq!(state.config.book.gap_mm, 5.0);
+        assert_eq!(state.config.book.dpi, 300.0);
+        assert!(state.config.preview.show_slot_info);
     }
 
     #[test]

--- a/tests/add_test.rs
+++ b/tests/add_test.rs
@@ -24,6 +24,7 @@ fn create_test_project(temp_dir: &TempDir) -> Result<PathBuf> {
         spine_grow_per_10_pages_mm: None,
         spine_mm: None,
         margin_mm: 0.0,
+        base_config: None,
     };
     let result = project_new(temp_dir.path(), &config)?;
     Ok(result.result.project_root)

--- a/tests/build_test.rs
+++ b/tests/build_test.rs
@@ -26,6 +26,7 @@ fn create_test_project_with_photos(temp_dir: &TempDir) -> Result<PathBuf> {
         spine_grow_per_10_pages_mm: None,
         spine_mm: None,
         margin_mm: 0.0,
+        base_config: None,
     };
     let result = project_new(temp_dir.path(), &config)?;
     let project_root = result.result.project_root;
@@ -78,6 +79,7 @@ fn create_test_project_with_artificial_photos_3(temp_dir: &TempDir) -> Result<Pa
         spine_grow_per_10_pages_mm: None,
         spine_mm: None,
         margin_mm: 0.0,
+        base_config: None,
     };
     let result = project_new(temp_dir.path(), &config)?;
     let project_root = result.result.project_root;
@@ -465,6 +467,7 @@ fn test_build_handles_empty_photo_list() -> Result<()> {
         spine_grow_per_10_pages_mm: None,
         spine_mm: None,
         margin_mm: 0.0,
+        base_config: None,
     };
     let result = project_new(temp_dir.path(), &config)?;
     let project_root = result.result.project_root;

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -21,6 +21,7 @@ fn create_test_project(temp_dir: &TempDir) -> Result<PathBuf> {
         spine_grow_per_10_pages_mm: None,
         spine_mm: None,
         margin_mm: 0.0,
+        base_config: None,
     };
     let result = project_new(temp_dir.path(), &config)?;
     Ok(result.result.project_root)

--- a/tests/place_test.rs
+++ b/tests/place_test.rs
@@ -22,6 +22,7 @@ fn create_test_project_with_layout(temp_dir: &TempDir) -> Result<PathBuf> {
         spine_grow_per_10_pages_mm: None,
         spine_mm: None,
         margin_mm: 0.0,
+        base_config: None,
     };
     let result = project_new(temp_dir.path(), &config)?;
     let project_root = result.result.project_root;
@@ -103,6 +104,7 @@ fn test_place_requires_layout() -> Result<()> {
         spine_grow_per_10_pages_mm: None,
         spine_mm: None,
         margin_mm: 0.0,
+        base_config: None,
     };
     let result = project_new(temp_dir.path(), &config)?;
     let project_root = result.result.project_root;

--- a/tests/project_new_test.rs
+++ b/tests/project_new_test.rs
@@ -21,6 +21,7 @@ fn test_project_new_mode1_creates_complete_structure() -> Result<()> {
         spine_grow_per_10_pages_mm: None,
         spine_mm: None,
         margin_mm: 0.0,
+        base_config: None,
     };
 
     let result = project_new(temp_dir.path(), &config)?;
@@ -97,6 +98,7 @@ fn test_project_new_mode2_creates_additional_project() -> Result<()> {
         spine_grow_per_10_pages_mm: None,
         spine_mm: None,
         margin_mm: 0.0,
+        base_config: None,
     };
     let result1 = project_new(temp_dir.path(), &config1)?;
 
@@ -113,6 +115,7 @@ fn test_project_new_mode2_creates_additional_project() -> Result<()> {
         spine_grow_per_10_pages_mm: None,
         spine_mm: None,
         margin_mm: 0.0,
+        base_config: None,
     };
     let result2 = project_new(&result1.result.project_root, &config2)?;
 
@@ -158,6 +161,7 @@ fn test_project_new_rejects_duplicate_name() -> Result<()> {
         spine_grow_per_10_pages_mm: None,
         spine_mm: None,
         margin_mm: 0.0,
+        base_config: None,
     };
 
     // Create first project
@@ -228,6 +232,7 @@ fn test_project_new_with_different_page_dimensions() -> Result<()> {
             spine_grow_per_10_pages_mm: None,
             spine_mm: None,
             margin_mm: 0.0,
+            base_config: None,
         };
 
         let result = project_new(temp_dir.path(), &config)?;

--- a/tests/rebuild_test.rs
+++ b/tests/rebuild_test.rs
@@ -25,6 +25,7 @@ fn create_test_project_with_build(temp_dir: &TempDir) -> Result<PathBuf> {
         spine_grow_per_10_pages_mm: None,
         spine_mm: None,
         margin_mm: 0.0,
+        base_config: None,
     };
     let result = project_new(temp_dir.path(), &config)?;
     let project_root = result.result.project_root;
@@ -460,6 +461,7 @@ fn test_rebuild_without_layout_fails_except_all() -> Result<()> {
         spine_grow_per_10_pages_mm: None,
         spine_mm: None,
         margin_mm: 0.0,
+        base_config: None,
     };
     let result = project_new(temp_dir.path(), &config)?;
     let project_root = result.result.project_root;

--- a/tests/remove_test.rs
+++ b/tests/remove_test.rs
@@ -23,6 +23,7 @@ fn create_test_project_with_layout(temp_dir: &TempDir) -> Result<PathBuf> {
         spine_grow_per_10_pages_mm: None,
         spine_mm: None,
         margin_mm: 0.0,
+        base_config: None,
     };
     let result = project_new(temp_dir.path(), &config)?;
     let project_root = result.result.project_root;

--- a/tests/status_test.rs
+++ b/tests/status_test.rs
@@ -21,6 +21,7 @@ fn create_test_project(temp_dir: &TempDir) -> Result<PathBuf> {
         spine_grow_per_10_pages_mm: None,
         spine_mm: None,
         margin_mm: 0.0,
+        base_config: None,
     };
     let result = project_new(temp_dir.path(), &config)?;
     Ok(result.result.project_root)


### PR DESCRIPTION
## Summary

Resolves #31.

- Adds `base_config: Option<ProjectConfig>` to `NewConfig`. When provided, it is used as the starting point in `generate_default_state`; the dimension, cover and title fields from `NewConfig` are overwritten on top of it. When `None`, defaults are used (unchanged behaviour).
- The GUI's *New Project* dialog now passes a base config with `show_slot_info`, `show_preview_watermark`, `show_borders` and `show_filenames` all set to `false`, since these overlays look cluttered in the GUI preview.

This removes the need to either extend `NewConfig` for every customizable parameter or run `config set` repeatedly after project creation.

## Implementation notes

- `generate_default_state` was refactored to start from the base config and spread the remaining fields (`..base.book`, `..base`), preserving solver/preview/appendix settings while still overwriting dimensions and cover as before. Defaults are identical to the previous hardcoded values.
- All existing `NewConfig` literals (CLI handler + tests) were updated with `base_config: None`.

## Tests

- Added `test_base_config_preserves_non_dimension_fields` and `test_default_base_config_uses_defaults` in `yaml.rs`.
- `cargo build`, `cargo clippy`, `cargo fmt`, lib + integration tests, and the GUI binary (`--features gui`) all pass.

https://claude.ai/code/session_01FENXPTZTpBJNE83WPQSRHH

---
_Generated by [Claude Code](https://claude.ai/code/session_01FENXPTZTpBJNE83WPQSRHH)_