### PR TITLE
feat: add preview.write_pdf option to skip pdf generation on build

### DIFF
--- a/docs/book/src/configuration.md
+++ b/docs/book/src/configuration.md
@@ -203,6 +203,7 @@ All preview overlay settings are automatically suppressed in `build release`.
 | `show_borders`           | `true`  | Show red bleed border and blue margin border overlays on each page.                                                   |
 | `show_slot_info`         | `true`  | Show slot address and area weight on each photo (e.g. `3:2 (1.5)`).                                                   |
 | `show_preview_watermark` | `true`  | Show a watermark on the preview images. Useful to easily distinguish preview images from final output.                |
+| `write_pdf`              | `true`  | Whether `build`/`rebuild` (re)write the preview PDF. Set to `false` to skip PDF generation (e.g. in the GUI, which renders pages directly) for faster builds. |
 
 ---
 

--- a/gui/app/widgets/new_project_dialog.rs
+++ b/gui/app/widgets/new_project_dialog.rs
@@ -117,12 +117,15 @@ fn parse_config(s: &NewProjectDialogState) -> Option<NewConfig> {
     };
 
     // Preview overlays look cluttered in the GUI, so disable them by default.
+    // The GUI renders pages directly, so writing the preview PDF on every build
+    // only slows page rendering down — disable it by default.
     let base_config = ProjectConfig {
         preview: PreviewConfig {
             show_slot_info: false,
             show_preview_watermark: false,
             show_borders: false,
             show_filenames: false,
+            write_pdf: false,
             ..Default::default()
         },
         ..Default::default()

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -115,11 +115,14 @@ pub fn build(
         return release_build(mgr, project_root, config.force);
     }
 
+    // Honor the project's `preview.write_pdf` setting in addition to the explicit flag.
+    let skip_pdf = config.skip_pdf || !mgr.state.config.preview.write_pdf;
+
     // First build vs incremental build
     if mgr.state.layout.is_empty() {
-        first_build(mgr, project_root, config.skip_pdf)
+        first_build(mgr, project_root, skip_pdf)
     } else {
-        incremental_build(mgr, project_root, config.pages.as_deref(), config.skip_pdf)
+        incremental_build(mgr, project_root, config.pages.as_deref(), skip_pdf)
     }
 }
 

--- a/src/commands/rebuild.rs
+++ b/src/commands/rebuild.rs
@@ -67,6 +67,9 @@ pub fn rebuild(
 
     validate_scope(&scope, &mgr)?;
 
+    // Honor the project's `preview.write_pdf` setting in addition to the explicit flag.
+    let skip_pdf = skip_pdf || !mgr.state.config.preview.write_pdf;
+
     match scope {
         RebuildScope::SinglePage(idx) => rebuild_single(mgr, project_root, idx, skip_pdf),
         RebuildScope::Range { start, end, flex } => {

--- a/src/dto_models/config/preview_config.rs
+++ b/src/dto_models/config/preview_config.rs
@@ -15,6 +15,11 @@ pub struct PreviewConfig {
     pub show_slot_info: bool,
     #[serde(default = "default_show_preview_watermark")]
     pub show_preview_watermark: bool,
+    /// Whether `build`/`rebuild` should (re)write the preview PDF.
+    /// Disabling this speeds up page rendering in the GUI, which renders pages
+    /// directly and does not depend on the preview PDF being on disk.
+    #[serde(default = "default_write_pdf")]
+    pub write_pdf: bool,
 }
 
 impl Default for PreviewConfig {
@@ -25,6 +30,7 @@ impl Default for PreviewConfig {
             show_borders: default_show_borders(),
             show_slot_info: default_show_slot_info(),
             show_preview_watermark: default_show_preview_watermark(),
+            write_pdf: default_write_pdf(),
         }
     }
 }
@@ -47,4 +53,30 @@ fn default_show_slot_info() -> bool {
 
 fn default_show_preview_watermark() -> bool {
     true
+}
+
+fn default_write_pdf() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_pdf_defaults_to_true() {
+        assert!(PreviewConfig::default().write_pdf);
+    }
+
+    #[test]
+    fn write_pdf_defaults_to_true_when_absent_in_yaml() {
+        let cfg: PreviewConfig = serde_yaml::from_str("show_filenames: true").unwrap();
+        assert!(cfg.write_pdf);
+    }
+
+    #[test]
+    fn write_pdf_roundtrips_false() {
+        let cfg: PreviewConfig = serde_yaml::from_str("write_pdf: false").unwrap();
+        assert!(!cfg.write_pdf);
+    }
 }

--- a/tests/build_test.rs
+++ b/tests/build_test.rs
@@ -915,3 +915,36 @@ fn incremental_build_skips_manual_page() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn build_does_not_write_pdf_when_write_pdf_disabled() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let project_root = create_test_project_with_photos(&temp_dir)?;
+
+    // Disable PDF writing via the project config.
+    let mut mgr = StateManager::open(&project_root)?;
+    mgr.state.config.preview.write_pdf = false;
+    mgr.finish("test: disable write_pdf")?;
+
+    // Build with skip_pdf=false — the config must still suppress the PDF.
+    let result = build(
+        &project_root,
+        &BuildConfig {
+            release: false,
+            force: false,
+            pages: None,
+            skip_pdf: false,
+        },
+    )?;
+
+    assert!(
+        !result.result.pages_rebuilt.is_empty(),
+        "layout should still be built"
+    );
+    assert!(
+        !result.result.pdf_path.exists(),
+        "PDF must not be written when preview.write_pdf is false"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Resolves #36.

Adds a new `ProjectConfig` option `preview.write_pdf` (default `true`). When set to `false`, `build` and `rebuild` no longer (re)write the preview PDF. The GUI renders pages directly and does not depend on the preview PDF, so new projects created from the GUI now default to `write_pdf = false` — this avoids waiting for the PDF to be written on every page build, making GUI page rendering faster.

## Changes

- **`preview.write_pdf` config field** (`PreviewConfig`), default `true`, with serde default so existing projects keep the old behavior.
- **`build` / `rebuild`** compute the effective skip as `skip_pdf || !preview.write_pdf`, reusing the existing `skip_pdf` plumbing (which already gates both the Typst PDF compilation and the preview image cache).
- **GUI default config** (`new_project_dialog`) sets `write_pdf = false` for newly created projects.
- Docs entry in `configuration.md`.

The existing `--skip-pdf` CLI flag and the generic `config set preview.write_pdf <bool>` both continue to work.

## Tests

- Unit tests for the default value and YAML (de)serialization of `write_pdf`.
- Integration test verifying that `build` does not write the PDF when `preview.write_pdf` is `false`, while still building the layout.

`cargo build`, `clippy` (workspace), `fmt` and the new tests all pass.

https://claude.ai/code/session_01RczPKRHa8N16cY76qjRGe8

---
_Generated by [Claude Code](https://claude.ai/code/session_01RczPKRHa8N16cY76qjRGe8)_