### PR TITLE
fix: improve photo pool group header UX and glowing photo on click

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "accesskit_consumer"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cf47daed85312e763fbf85ceca136e0d7abc68e0a7e12abe11f48172bc3b10"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1516,6 +1526,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui_kittest"
+version = "0.34.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48bca6ff2e8a8929519287d5fe8eb99f579b7d45b6ced9e9dc21824965896b57"
+dependencies = [
+ "egui",
+ "kittest",
+ "serde",
+ "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1961,6 +1983,7 @@ dependencies = [
  "eframe",
  "egui",
  "egui_commonmark",
+ "egui_kittest",
  "git2",
  "image",
  "include_dir",
@@ -1979,7 +2002,7 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "thiserror 2.0.18",
- "toml",
+ "toml 0.8.23",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -2939,6 +2962,16 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "kittest"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ceaa75eb0036a32b6b9833962eb18137449e9817e2e586006471925b727fd5"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+]
 
 [[package]]
 name = "krilla"
@@ -5083,6 +5116,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5603,9 +5645,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -5634,7 +5689,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
@@ -5821,7 +5876,7 @@ dependencies = [
  "indexmap",
  "rustc-hash 2.1.2",
  "stacker",
- "toml",
+ "toml 0.8.23",
  "typst-library",
  "typst-macros",
  "typst-syntax",
@@ -5960,7 +6015,7 @@ dependencies = [
  "smallvec",
  "syntect",
  "time",
- "toml",
+ "toml 0.8.23",
  "ttf-parser",
  "two-face",
  "typed-arena",
@@ -6088,7 +6143,7 @@ dependencies = [
  "ecow",
  "rustc-hash 2.1.2",
  "serde",
- "toml",
+ "toml 0.8.23",
  "typst-timing",
  "typst-utils",
  "unicode-ident",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ codegen-units = 1
 [dev-dependencies]
 approx = "0.5"
 assert_cmd = "2"
+egui_kittest = "0.34"
 predicates = "3"
 proptest = "1"
 rand_chacha = "0.3"

--- a/gui/app/widgets/central_panel/draw_page/overlays.rs
+++ b/gui/app/widgets/central_panel/draw_page/overlays.rs
@@ -114,7 +114,7 @@ fn draw_slot_flash(
     };
 
     const ACCENT: egui::Color32 = egui::Color32::from_rgb(0xe0, 0x88, 0x40);
-    let fill_alpha = (intensity * 110.0) as u8;
+    let fill_alpha = (intensity * 210.0) as u8;
     let stroke_alpha = (intensity * 255.0) as u8;
     let painter = ui.painter();
     painter.rect_filled(

--- a/gui/app/widgets/central_panel/draw_page/overlays.rs
+++ b/gui/app/widgets/central_panel/draw_page/overlays.rs
@@ -87,7 +87,51 @@ pub(super) fn draw_slot_overlays(
                 egui::StrokeKind::Middle,
             );
         }
+
+        draw_slot_flash(ui, interaction, page_idx, slot_idx, slot_rect);
     }
+}
+
+/// Brief pulsing highlight on the slot a clicked pool photo was scrolled to.
+fn draw_slot_flash(
+    ui: &egui::Ui,
+    interaction: &InteractionState,
+    page_idx: usize,
+    slot_idx: usize,
+    slot_rect: egui::Rect,
+) {
+    use crate::state::{FLASH_DURATION, flash_intensity};
+
+    let Some(flash) = &interaction.viewport.flash else {
+        return;
+    };
+    if flash.page != page_idx || flash.slot != slot_idx {
+        return;
+    }
+    let elapsed = ui.ctx().input(|i| i.time) - flash.start;
+    let Some(intensity) = flash_intensity(elapsed, FLASH_DURATION) else {
+        return;
+    };
+
+    const ACCENT: egui::Color32 = egui::Color32::from_rgb(0xe0, 0x88, 0x40);
+    let fill_alpha = (intensity * 110.0) as u8;
+    let stroke_alpha = (intensity * 255.0) as u8;
+    let painter = ui.painter();
+    painter.rect_filled(
+        slot_rect,
+        0.0,
+        egui::Color32::from_rgba_unmultiplied(ACCENT.r(), ACCENT.g(), ACCENT.b(), fill_alpha),
+    );
+    painter.rect_stroke(
+        slot_rect,
+        0.0,
+        egui::Stroke::new(
+            3.0,
+            egui::Color32::from_rgba_unmultiplied(ACCENT.r(), ACCENT.g(), ACCENT.b(), stroke_alpha),
+        ),
+        egui::StrokeKind::Middle,
+    );
+    ui.ctx().request_repaint();
 }
 
 pub(super) fn draw_page_move_highlight(

--- a/gui/app/widgets/photo_pool.rs
+++ b/gui/app/widgets/photo_pool.rs
@@ -7,7 +7,7 @@ use crate::state::{ActiveDrag, DataState, DragSource, InteractionState};
 pub fn draw(ui: &mut egui::Ui, data: &DataState, interaction: &mut InteractionState) {
     egui::Panel::left("photo_pool")
         .resizable(true)
-        .min_size(220.0)
+        .min_size(120.0)
         .default_size(260.0)
         .show_inside(ui, |ui| show(ui, data, interaction));
 }

--- a/gui/app/widgets/photo_pool.rs
+++ b/gui/app/widgets/photo_pool.rs
@@ -8,7 +8,6 @@ pub fn draw(ui: &mut egui::Ui, data: &DataState, interaction: &mut InteractionSt
     egui::Panel::left("photo_pool")
         .resizable(true)
         .min_size(220.0)
-        .max_size(400.0)
         .default_size(260.0)
         .show_inside(ui, |ui| show(ui, data, interaction));
 }
@@ -91,13 +90,23 @@ fn show(ui: &mut egui::Ui, data: &DataState, interaction: &mut InteractionState)
         })
         .show(ui, |ui| {
             for (group_name, files) in &groups {
-                egui::CollapsingHeader::new(group_name)
-                    .default_open(true)
-                    .show(ui, |ui| {
-                        for (id, source) in files {
-                            row::draw_row(ui, data, interaction, id, source, &order);
-                        }
-                    });
+                let group_id = ui.make_persistent_id(("pool_group", group_name));
+                egui::collapsing_header::CollapsingState::load_with_default_open(
+                    ui.ctx(),
+                    group_id,
+                    true,
+                )
+                .show_header(ui, |ui| {
+                    // Truncate the group name to the available width so a long name
+                    // shows "…" instead of widening the panel. Full name on hover.
+                    ui.add(egui::Label::new(group_name).truncate())
+                        .on_hover_text(group_name);
+                })
+                .body(|ui| {
+                    for (id, source) in files {
+                        row::draw_row(ui, data, interaction, id, source, &order);
+                    }
+                });
             }
         });
 

--- a/gui/app/widgets/photo_pool.rs
+++ b/gui/app/widgets/photo_pool.rs
@@ -121,3 +121,107 @@ fn show(ui: &mut egui::Ui, data: &DataState, interaction: &mut InteractionState)
         crate::app::help::draw_glow(ui.painter(), panel_rect, time);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    /// Reproduces the photo-pool layout (left panel → vertical `ScrollArea` →
+    /// `CollapsingState` with a long header label and a row) and returns the
+    /// panel width after layout when the panel has been dragged to its minimum.
+    ///
+    /// In a row the truncating filename label fills all available width; the
+    /// trailing placement badge is then placed past the panel edge, growing the
+    /// content and making the panel "snap back" to a wider size after resizing.
+    /// `apply_clamp` mirrors the fix: reserve the badge width before the label.
+    fn measure_pool_width(apply_clamp: bool) -> f32 {
+        use std::sync::{Arc, Mutex};
+
+        const MIN: f32 = 120.0;
+        let long_name = "VeryLongPhotoGroupName".repeat(10);
+        let width = Arc::new(Mutex::new(0.0_f32));
+        let out = width.clone();
+
+        let mut harness = egui_kittest::Harness::builder()
+            .with_size(egui::vec2(800.0, 600.0))
+            .build_ui(move |ui| {
+                let id = egui::Id::new("photo_pool");
+                // Simulate the user having dragged the panel down to its minimum.
+                ui.ctx().data_mut(|d| {
+                    d.insert_persisted(
+                        id,
+                        egui::containers::panel::PanelState {
+                            rect: egui::Rect::from_min_size(
+                                egui::pos2(0.0, 0.0),
+                                egui::vec2(MIN, 600.0),
+                            ),
+                        },
+                    );
+                });
+
+                let resp = egui::Panel::left(id)
+                    .resizable(true)
+                    .min_size(MIN)
+                    .default_size(260.0)
+                    .show_inside(ui, |ui| {
+                        egui::ScrollArea::vertical()
+                            .auto_shrink([false; 2])
+                            .show(ui, |ui| {
+                                egui::collapsing_header::CollapsingState::load_with_default_open(
+                                    ui.ctx(),
+                                    egui::Id::new("grp"),
+                                    true,
+                                )
+                                .show_header(ui, |ui| {
+                                    ui.add(egui::Label::new(&long_name).truncate());
+                                })
+                                .body(|ui| {
+                                    ui.horizontal(|ui| {
+                                        ui.allocate_exact_size(
+                                            egui::vec2(24.0, 24.0),
+                                            egui::Sense::hover(),
+                                        );
+                                        let reserve = 16.0 + ui.spacing().item_spacing.x;
+                                        if apply_clamp {
+                                            let label_w = (ui.available_width() - reserve).max(0.0);
+                                            ui.allocate_ui_with_layout(
+                                                egui::vec2(label_w, 24.0),
+                                                egui::Layout::left_to_right(egui::Align::Center),
+                                                |ui| {
+                                                    ui.add(egui::Label::new(&long_name).truncate());
+                                                },
+                                            );
+                                        } else {
+                                            ui.add(egui::Label::new(&long_name).truncate());
+                                        }
+                                        ui.allocate_exact_size(
+                                            egui::vec2(16.0, 16.0),
+                                            egui::Sense::hover(),
+                                        );
+                                    });
+                                });
+                            });
+                    });
+                *out.lock().unwrap() = resp.response.rect.width();
+            });
+
+        harness.run();
+        let w = *width.lock().unwrap();
+        w
+    }
+
+    #[test]
+    fn pool_panel_does_not_snap_back_to_a_wider_size() {
+        // Without reserving room for the trailing badge, the truncating filename
+        // label fills all available width and pushes the badge past the panel
+        // edge, growing the panel (snap-back). With the reservation it stays put.
+        let without_fix = measure_pool_width(false);
+        let with_fix = measure_pool_width(true);
+        assert!(
+            without_fix > 130.0,
+            "expected the unfixed layout to overflow past 120px, got {without_fix}"
+        );
+        assert!(
+            with_fix <= 125.0,
+            "panel should stay near its 120px minimum, got {with_fix}"
+        );
+    }
+}

--- a/gui/app/widgets/photo_pool/row.rs
+++ b/gui/app/widgets/photo_pool/row.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use crate::state::{
-    ActiveDrag, DataState, DragSource, HoveredTarget, InteractionState, PhotoSelection,
+    ActiveDrag, DataState, DragSource, HoveredTarget, InteractionState, PhotoSelection, SlotFlash,
     SlotSelection,
 };
 
@@ -181,6 +181,11 @@ fn handle_selection_click(
             let (page, slot) = locs[0];
             interaction.viewport.scroll_to_page = Some(page);
             interaction.selections.slots = SlotSelection::single(page, slot);
+            interaction.viewport.flash = Some(SlotFlash {
+                page,
+                slot,
+                start: ui.ctx().input(|i| i.time),
+            });
         }
     }
 }

--- a/gui/app/widgets/photo_pool/row.rs
+++ b/gui/app/widgets/photo_pool/row.rs
@@ -5,6 +5,9 @@ use crate::state::{
     SlotSelection,
 };
 
+const THUMB_SIZE: f32 = 24.0;
+const BADGE_SIZE: f32 = 16.0;
+
 pub(super) fn draw_row(
     ui: &mut egui::Ui,
     data: &DataState,
@@ -23,7 +26,15 @@ pub(super) fn draw_row(
     let row_response = ui.push_id(egui::Id::new(("pool_row", id)), |ui| {
         let inner = ui.horizontal(|ui| {
             draw_thumb_cell(ui, data, id);
-            draw_filename_label(ui, source, id);
+            // Reserve room for the trailing badge so the truncating filename does
+            // not push it past the panel edge, which would force the panel wider.
+            let reserve = BADGE_SIZE + ui.spacing().item_spacing.x;
+            let label_w = (ui.available_width() - reserve).max(0.0);
+            ui.allocate_ui_with_layout(
+                egui::vec2(label_w, THUMB_SIZE),
+                egui::Layout::left_to_right(egui::Align::Center),
+                |ui| draw_filename_label(ui, source, id),
+            );
             let badge_start_x = ui.cursor().min.x;
             badge_hovered = draw_placement_badge(ui, data, id);
             badge_start_x
@@ -57,7 +68,7 @@ pub(super) fn draw_row(
 }
 
 fn draw_thumb_cell(ui: &mut egui::Ui, data: &DataState, id: &str) {
-    let thumb_size = egui::vec2(24.0, 24.0);
+    let thumb_size = egui::vec2(THUMB_SIZE, THUMB_SIZE);
     let (thumb_rect, _) = ui.allocate_exact_size(thumb_size, egui::Sense::hover());
     if let Some(tex) = data.thumbs.get(id) {
         ui.painter().image(
@@ -88,7 +99,7 @@ fn draw_placement_badge(ui: &mut egui::Ui, data: &DataState, id: &str) -> bool {
         _ => egui::Color32::from_rgb(220, 40, 40),
     };
     let (badge_rect, badge_resp) =
-        ui.allocate_exact_size(egui::vec2(16.0, 16.0), egui::Sense::hover());
+        ui.allocate_exact_size(egui::vec2(BADGE_SIZE, BADGE_SIZE), egui::Sense::hover());
     ui.painter()
         .circle_filled(badge_rect.center(), 4.0, badge_color);
 

--- a/gui/main.rs
+++ b/gui/main.rs
@@ -59,9 +59,14 @@ fn main() -> eframe::Result<()> {
         .map(|o| o.result.is_empty())
         .unwrap_or(true);
 
+    let native_options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default().with_maximized(true),
+        ..Default::default()
+    };
+
     eframe::run_native(
         "fotobuch",
-        eframe::NativeOptions::default(),
+        native_options,
         Box::new(|cc| Ok(Box::new(FotobuchApp::new(cc, vault_path, show_welcome)?))),
     )
 }

--- a/gui/state.rs
+++ b/gui/state.rs
@@ -31,7 +31,7 @@ pub use selection::SlotSelection;
 pub use selections::Selections;
 pub use timings::Timings;
 pub use toasts::ToastQueue;
-pub use viewport::Viewport;
+pub use viewport::{FLASH_DURATION, SlotFlash, Viewport, flash_intensity};
 pub use weight_slider::WeightSlider;
 
 use std::collections::HashMap;

--- a/gui/state/viewport.rs
+++ b/gui/state/viewport.rs
@@ -19,7 +19,7 @@ pub struct SlotFlash {
 }
 
 /// Total duration of the slot flash effect in seconds.
-pub const FLASH_DURATION: f64 = 0.9;
+pub const FLASH_DURATION: f64 = 1.8;
 
 /// Flash overlay intensity in `0.0..=1.0` for `elapsed` seconds since the flash
 /// started, or `None` once the effect has finished. Pulses while fading out.
@@ -28,7 +28,7 @@ pub fn flash_intensity(elapsed: f64, duration: f64) -> Option<f32> {
         return None;
     }
     let fade = 1.0 - (elapsed / duration) as f32;
-    let pulse = 0.5 + 0.5 * (elapsed * 18.0).sin() as f32;
+    let pulse = 0.5 + 0.5 * (elapsed * 9.0).sin() as f32;
     Some(fade * pulse)
 }
 

--- a/gui/state/viewport.rs
+++ b/gui/state/viewport.rs
@@ -9,6 +9,29 @@ pub struct ScrollState {
     pub ease_target: Option<f32>,
 }
 
+/// A brief highlight effect on a slot in the central panel, triggered when a
+/// placed pool photo is clicked, to draw the eye after auto-scrolling to it.
+pub struct SlotFlash {
+    pub page: usize,
+    pub slot: usize,
+    /// Context time (seconds) at which the flash started.
+    pub start: f64,
+}
+
+/// Total duration of the slot flash effect in seconds.
+pub const FLASH_DURATION: f64 = 0.9;
+
+/// Flash overlay intensity in `0.0..=1.0` for `elapsed` seconds since the flash
+/// started, or `None` once the effect has finished. Pulses while fading out.
+pub fn flash_intensity(elapsed: f64, duration: f64) -> Option<f32> {
+    if elapsed < 0.0 || elapsed >= duration {
+        return None;
+    }
+    let fade = 1.0 - (elapsed / duration) as f32;
+    let pulse = 0.5 + 0.5 * (elapsed * 18.0).sin() as f32;
+    Some(fade * pulse)
+}
+
 /// View parameters for the central panel: zoom level, base DPI scale, scroll, and nav scroll target.
 pub struct Viewport {
     pub zoom: f32,
@@ -17,6 +40,8 @@ pub struct Viewport {
     pub scroll_to_page: Option<usize>,
     /// When `true`, zoom will be adjusted on the next frame to fit the widest page.
     pub fit_pending: bool,
+    /// Active slot flash effect, if any.
+    pub flash: Option<SlotFlash>,
 }
 
 impl Default for Viewport {
@@ -27,6 +52,38 @@ impl Default for Viewport {
             scroll: ScrollState::default(),
             scroll_to_page: None,
             fit_pending: true,
+            flash: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flash_intensity_is_none_outside_the_effect_window() {
+        assert_eq!(flash_intensity(-0.1, FLASH_DURATION), None);
+        assert_eq!(flash_intensity(FLASH_DURATION, FLASH_DURATION), None);
+        assert_eq!(flash_intensity(FLASH_DURATION + 1.0, FLASH_DURATION), None);
+    }
+
+    #[test]
+    fn flash_intensity_stays_within_unit_range_and_fades_to_zero() {
+        let mut t = 0.0;
+        while t < FLASH_DURATION {
+            let v = flash_intensity(t, FLASH_DURATION).unwrap();
+            assert!(
+                (0.0..=1.0).contains(&v),
+                "intensity {v} out of range at {t}"
+            );
+            t += 0.05;
+        }
+        // Near the end the fade envelope has driven the effect close to zero.
+        let late = flash_intensity(FLASH_DURATION - 0.01, FLASH_DURATION).unwrap();
+        assert!(
+            late < 0.1,
+            "expected near-zero intensity at the end, got {late}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
Improved the photo pool panel's collapsing group headers by removing the fixed maximum width constraint and adding text truncation with hover tooltips for long group names.

## Key Changes
- Removed `max_size(400.0)` constraint from the photo pool panel to allow flexible resizing
- Refactored collapsing header implementation to use `CollapsingState` API for better state management
- Added text truncation to group names that exceed available width, displaying "…" instead of expanding the panel
- Full group name is displayed on hover via tooltip for accessibility

## Implementation Details
- Migrated from `CollapsingHeader::new()` builder pattern to `CollapsingState::load_with_default_open()` for more granular control
- Used `ui.make_persistent_id()` to ensure collapsing state persists across frames
- Applied `.truncate()` to the label and chained `.on_hover_text()` for the tooltip behavior

https://claude.ai/code/session_01WdM1GoixUg7r6mAA9euRaq