### PR TITLE
feat(cover): add CoverGeometry value object

### DIFF
--- a/src/commands/build/build_layout/cover_page.rs
+++ b/src/commands/build/build_layout/cover_page.rs
@@ -1,4 +1,4 @@
-use crate::dto_models::{CanvasConfig, CoverConfig, LayoutPage, PageMode, PhotoFile, PhotoGroup};
+use crate::dto_models::{CoverConfig, CoverGeometry, LayoutPage, PageMode, PhotoFile, PhotoGroup};
 use crate::run_solver;
 use crate::solver::cover_solver::{compute_cover_slots, warn_slot_count_mismatch};
 use crate::solver::{Request, RequestType};
@@ -47,10 +47,7 @@ fn update_cover_free(
 ) -> Result<()> {
     let cover = &state.config.book.cover;
     let inner_page_count = state.layout.len() - 1;
-    let spread_config = CoverCanvasConfig {
-        cover,
-        inner_page_count,
-    };
+    let spread_config = CoverGeometry::new(cover, inner_page_count);
     let group = PhotoGroup {
         group: "page_0".to_string(),
         sort_key: String::new(),
@@ -125,33 +122,6 @@ pub(super) fn split_cover_photos(
     }
 
     (cover_files, remaining)
-}
-
-/// Presents the full cover spread (front + back + spine) as `page_width_mm` to the GA solver.
-struct CoverCanvasConfig<'a> {
-    cover: &'a CoverConfig,
-    inner_page_count: usize,
-}
-
-impl CanvasConfig for CoverCanvasConfig<'_> {
-    fn page_width_mm(&self) -> f64 {
-        self.cover.spread_width_mm(self.inner_page_count)
-    }
-    fn page_height_mm(&self) -> f64 {
-        self.cover.height_mm
-    }
-    fn bleed_mm(&self) -> f64 {
-        self.cover.bleed_mm
-    }
-    fn margin_mm(&self) -> f64 {
-        self.cover.margin_mm
-    }
-    fn gap_mm(&self) -> f64 {
-        self.cover.gap_mm
-    }
-    fn bleed_threshold_mm(&self) -> f64 {
-        self.cover.bleed_threshold_mm
-    }
 }
 
 // ── tests ─────────────────────────────────────────────────────────────────────

--- a/src/commands/page/info.rs
+++ b/src/commands/page/info.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::commands::CommandOutput;
-use crate::dto_models::{PhotoFile, ProjectState};
+use crate::dto_models::{CoverGeometry, PhotoFile, ProjectState};
 
 use super::helpers::{page_idx, resolve_slots};
 use super::types::{InfoFilter, PageInfoResult, PageMoveError, SlotInfo, Src};
@@ -15,7 +15,7 @@ fn page_dims(state: &ProjectState, idx: usize) -> (bool, f64, f64) {
         let inner = state.layout.len() - 1;
         (
             true,
-            book.cover.spread_width_mm(inner),
+            CoverGeometry::new(&book.cover, inner).spread_width_mm(),
             book.cover.height_mm,
         )
     } else {

--- a/src/dto_models.rs
+++ b/src/dto_models.rs
@@ -6,6 +6,7 @@
 //! - **Layout**: PhotoPlacement, SolverPageLayout, BookLayout
 //! - **Request**: SolverRequest
 mod config;
+mod cover;
 mod layout;
 mod photos;
 mod state;
@@ -14,6 +15,7 @@ pub use config::{
     AppendixConfig, BookConfig, BookLayoutSolverConfig, CanvasConfig, CoverConfig, CoverMode,
     FitnessWeights, GaConfig, PreviewConfig, ProjectConfig, SpineConfig, ValidationError,
 };
+pub use cover::CoverGeometry;
 pub use layout::{LayoutPage, PageMode, Slot};
 pub use photos::{PhotoFile, PhotoGroup, build_photo_index};
 pub use state::ProjectState;

--- a/src/dto_models/config/cover_config.rs
+++ b/src/dto_models/config/cover_config.rs
@@ -1,8 +1,5 @@
 use serde::{Deserialize, Serialize};
 
-use crate::dto_models::config::book_config::CanvasConfig;
-use crate::dto_models::cover::CoverGeometry;
-
 /// Layout mode for the cover page.
 ///
 /// Controls whether the GA solver or the deterministic cover solver is used for
@@ -142,133 +139,9 @@ impl Default for CoverConfig {
     }
 }
 
-impl CoverConfig {
-    /// Total cover spread width. Delegates to `CoverGeometry`.
-    pub fn spread_width_mm(&self, inner_page_count: usize) -> f64 {
-        CoverGeometry::new(self, inner_page_count).spread_width_mm()
-    }
-
-    /// Spine width in mm. Delegates to `CoverGeometry`.
-    pub fn spine_width_mm(&self, inner_page_count: usize) -> f64 {
-        CoverGeometry::new(self, inner_page_count).spine_width_mm()
-    }
-
-    /// Resolved spine text: explicit value or fallback to book title.
-    pub fn resolved_spine_text<'a>(&'a self, book_title: &'a str) -> &'a str {
-        self.spine_text.as_deref().unwrap_or(book_title)
-    }
-}
-
-impl CanvasConfig for CoverConfig {
-    /// Returns the full spread width (front + back + spine).
-    /// Caller must pass the correct inner_page_count via spread_width_mm() when
-    /// constructing the solver canvas — this value excludes the spine.
-    fn page_width_mm(&self) -> f64 {
-        self.front_back_width_mm
-    }
-    fn page_height_mm(&self) -> f64 {
-        self.height_mm
-    }
-    fn bleed_mm(&self) -> f64 {
-        self.bleed_mm
-    }
-    fn margin_mm(&self) -> f64 {
-        self.margin_mm
-    }
-    fn gap_mm(&self) -> f64 {
-        self.gap_mm
-    }
-    fn bleed_threshold_mm(&self) -> f64 {
-        self.bleed_threshold_mm
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn cfg_auto(spine_mm_per_10_pages: f64) -> CoverConfig {
-        CoverConfig {
-            active: true,
-            mode: CoverMode::Free,
-            spine_clearance_mm: 5.0,
-            spine: SpineConfig::Auto {
-                spine_mm_per_10_pages,
-            },
-            front_back_width_mm: 420.0,
-            height_mm: 297.0,
-            spine_text: None,
-            bleed_mm: 3.0,
-            margin_mm: 0.0,
-            gap_mm: 5.0,
-            bleed_threshold_mm: 3.0,
-        }
-    }
-
-    fn cfg_fixed(spine_width_mm: f64) -> CoverConfig {
-        CoverConfig {
-            active: true,
-            mode: CoverMode::Free,
-            spine_clearance_mm: 5.0,
-            spine: SpineConfig::Fixed { spine_width_mm },
-            front_back_width_mm: 420.0,
-            height_mm: 297.0,
-            spine_text: None,
-            bleed_mm: 3.0,
-            margin_mm: 0.0,
-            gap_mm: 5.0,
-            bleed_threshold_mm: 3.0,
-        }
-    }
-
-    #[test]
-    fn spine_width_auto_linear() {
-        let c = cfg_auto(1.4);
-        assert!((c.spine_width_mm(10) - 1.4).abs() < 1e-9);
-        assert!((c.spine_width_mm(100) - 14.0).abs() < 1e-9);
-        assert!((c.spine_width_mm(0) - 0.0).abs() < 1e-9);
-    }
-
-    #[test]
-    fn spine_width_fixed() {
-        let c = cfg_fixed(2.5);
-        assert!((c.spine_width_mm(10) - 2.5).abs() < 1e-9);
-        assert!((c.spine_width_mm(100) - 2.5).abs() < 1e-9);
-        assert!((c.spine_width_mm(0) - 2.5).abs() < 1e-9);
-    }
-
-    #[test]
-    fn spread_width_auto_no_spine() {
-        let c = cfg_auto(1.0);
-        assert!((c.spread_width_mm(0) - 420.0).abs() < 1e-9);
-    }
-
-    #[test]
-    fn spread_width_auto_includes_spine() {
-        let c = cfg_auto(1.4);
-        assert!((c.spread_width_mm(10) - 421.4).abs() < 1e-9);
-    }
-
-    #[test]
-    fn spread_width_fixed_ignores_spine() {
-        let c = cfg_fixed(2.5);
-        // Fixed mode: spread width is always front_back_width, regardless of page count
-        assert!((c.spread_width_mm(10) - 420.0).abs() < 1e-9);
-        assert!((c.spread_width_mm(100) - 420.0).abs() < 1e-9);
-    }
-
-    #[test]
-    fn resolved_spine_text_fallback() {
-        let c = cfg_auto(1.0);
-        assert_eq!(c.resolved_spine_text("Mein Buch"), "Mein Buch");
-    }
-
-    #[test]
-    fn resolved_spine_text_explicit() {
-        let mut c = cfg_auto(1.0);
-        c.spine_text = Some("Override".into());
-        assert_eq!(c.resolved_spine_text("Mein Buch"), "Override");
-    }
 
     #[test]
     fn cover_mode_required_slots() {

--- a/src/dto_models/config/cover_config.rs
+++ b/src/dto_models/config/cover_config.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::dto_models::config::book_config::CanvasConfig;
+use crate::dto_models::cover::CoverGeometry;
 
 /// Layout mode for the cover page.
 ///
@@ -142,34 +143,19 @@ impl Default for CoverConfig {
 }
 
 impl CoverConfig {
-    /// Total cover spread width in auto mode: front_back_width_mm + spine.
-    /// In fixed mode: only front_back_width_mm (spine doesn't affect solver canvas).
+    /// Total cover spread width. Delegates to `CoverGeometry`.
     pub fn spread_width_mm(&self, inner_page_count: usize) -> f64 {
-        match &self.spine {
-            SpineConfig::Auto { .. } => {
-                self.front_back_width_mm + self.spine_width_mm(inner_page_count)
-            }
-            SpineConfig::Fixed { .. } => {
-                // Fixed spine does not affect cover width
-                self.front_back_width_mm
-            }
-        }
+        CoverGeometry::new(self, inner_page_count).spread_width_mm()
+    }
+
+    /// Spine width in mm. Delegates to `CoverGeometry`.
+    pub fn spine_width_mm(&self, inner_page_count: usize) -> f64 {
+        CoverGeometry::new(self, inner_page_count).spine_width_mm()
     }
 
     /// Resolved spine text: explicit value or fallback to book title.
     pub fn resolved_spine_text<'a>(&'a self, book_title: &'a str) -> &'a str {
         self.spine_text.as_deref().unwrap_or(book_title)
-    }
-
-    /// Spine width in mm. In auto mode, calculated from page count. In fixed mode, the provided value.
-    /// Used by template for display/text sizing in both modes.
-    pub fn spine_width_mm(&self, inner_page_count: usize) -> f64 {
-        match &self.spine {
-            SpineConfig::Auto {
-                spine_mm_per_10_pages,
-            } => (inner_page_count as f64 / 10.0) * spine_mm_per_10_pages,
-            SpineConfig::Fixed { spine_width_mm } => *spine_width_mm,
-        }
     }
 }
 

--- a/src/dto_models/cover.rs
+++ b/src/dto_models/cover.rs
@@ -1,0 +1,147 @@
+use crate::dto_models::config::{CanvasConfig, CoverConfig, SpineConfig};
+
+/// Geometry value object: binds a `CoverConfig` to a concrete `inner_page_count`
+/// and owns all dimension calculations.
+///
+/// `CoverConfig` is a pure data DTO; this type holds the calculations that require
+/// the runtime value `inner_page_count`.
+pub struct CoverGeometry<'a> {
+    cover: &'a CoverConfig,
+    inner_page_count: usize,
+}
+
+impl<'a> CoverGeometry<'a> {
+    pub fn new(cover: &'a CoverConfig, inner_page_count: usize) -> Self {
+        Self {
+            cover,
+            inner_page_count,
+        }
+    }
+
+    /// Total spread width: front + back + spine (auto mode) or front + back only (fixed mode).
+    pub fn spread_width_mm(&self) -> f64 {
+        match &self.cover.spine {
+            SpineConfig::Auto { .. } => self.cover.front_back_width_mm + self.spine_width_mm(),
+            SpineConfig::Fixed { .. } => self.cover.front_back_width_mm,
+        }
+    }
+
+    /// Spine width: calculated from page count (auto) or user-supplied (fixed).
+    pub fn spine_width_mm(&self) -> f64 {
+        match &self.cover.spine {
+            SpineConfig::Auto {
+                spine_mm_per_10_pages,
+            } => (self.inner_page_count as f64 / 10.0) * spine_mm_per_10_pages,
+            SpineConfig::Fixed { spine_width_mm } => *spine_width_mm,
+        }
+    }
+
+    pub fn height_mm(&self) -> f64 {
+        self.cover.height_mm
+    }
+}
+
+impl CanvasConfig for CoverGeometry<'_> {
+    fn page_width_mm(&self) -> f64 {
+        self.spread_width_mm()
+    }
+    fn page_height_mm(&self) -> f64 {
+        self.cover.height_mm
+    }
+    fn bleed_mm(&self) -> f64 {
+        self.cover.bleed_mm
+    }
+    fn margin_mm(&self) -> f64 {
+        self.cover.margin_mm
+    }
+    fn gap_mm(&self) -> f64 {
+        self.cover.gap_mm
+    }
+    fn bleed_threshold_mm(&self) -> f64 {
+        self.cover.bleed_threshold_mm
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dto_models::config::{CoverMode, SpineConfig};
+
+    fn cfg_auto(front_back: f64, spine_per_10: f64) -> CoverConfig {
+        CoverConfig {
+            active: true,
+            mode: CoverMode::Free,
+            spine_clearance_mm: 5.0,
+            spine: SpineConfig::Auto {
+                spine_mm_per_10_pages: spine_per_10,
+            },
+            front_back_width_mm: front_back,
+            height_mm: 297.0,
+            spine_text: None,
+            bleed_mm: 3.0,
+            margin_mm: 0.0,
+            gap_mm: 5.0,
+            bleed_threshold_mm: 3.0,
+        }
+    }
+
+    fn cfg_fixed(front_back: f64, spine: f64) -> CoverConfig {
+        CoverConfig {
+            active: true,
+            mode: CoverMode::Free,
+            spine_clearance_mm: 5.0,
+            spine: SpineConfig::Fixed {
+                spine_width_mm: spine,
+            },
+            front_back_width_mm: front_back,
+            height_mm: 297.0,
+            spine_text: None,
+            bleed_mm: 3.0,
+            margin_mm: 0.0,
+            gap_mm: 5.0,
+            bleed_threshold_mm: 3.0,
+        }
+    }
+
+    #[test]
+    fn spine_width_auto() {
+        let c = cfg_auto(420.0, 1.4);
+        let g = CoverGeometry::new(&c, 10);
+        assert!((g.spine_width_mm() - 1.4).abs() < 1e-9);
+        let g100 = CoverGeometry::new(&c, 100);
+        assert!((g100.spine_width_mm() - 14.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn spine_width_fixed() {
+        let c = cfg_fixed(420.0, 2.5);
+        let g = CoverGeometry::new(&c, 10);
+        assert!((g.spine_width_mm() - 2.5).abs() < 1e-9);
+        let g100 = CoverGeometry::new(&c, 100);
+        assert!((g100.spine_width_mm() - 2.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn spread_width_auto_includes_spine() {
+        let c = cfg_auto(420.0, 1.4);
+        let g = CoverGeometry::new(&c, 10);
+        assert!((g.spread_width_mm() - 421.4).abs() < 1e-9);
+    }
+
+    #[test]
+    fn spread_width_fixed_ignores_page_count() {
+        let c = cfg_fixed(420.0, 2.5);
+        let g10 = CoverGeometry::new(&c, 10);
+        let g100 = CoverGeometry::new(&c, 100);
+        assert!((g10.spread_width_mm() - 420.0).abs() < 1e-9);
+        assert!((g100.spread_width_mm() - 420.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn canvas_config_uses_spread_width() {
+        let c = cfg_auto(420.0, 1.4);
+        let g = CoverGeometry::new(&c, 10);
+        assert!((g.page_width_mm() - g.spread_width_mm()).abs() < 1e-9);
+        assert!((g.page_height_mm() - 297.0).abs() < 1e-9);
+    }
+}

--- a/src/dto_models/state.rs
+++ b/src/dto_models/state.rs
@@ -65,7 +65,7 @@ impl ProjectState {
         if self.has_cover() && page == 0 {
             let inner_count = self.layout.len().saturating_sub(1);
             (
-                self.config.book.cover.spread_width_mm(inner_count),
+                CoverGeometry::new(&self.config.book.cover, inner_count).spread_width_mm(),
                 self.config.book.cover.height_mm,
             )
         } else {

--- a/src/solver/cover_solver.rs
+++ b/src/solver/cover_solver.rs
@@ -26,7 +26,7 @@
 use anyhow::{Result, bail};
 use tracing::warn;
 
-use crate::dto_models::{CoverConfig, CoverMode, Slot};
+use crate::dto_models::{CoverConfig, CoverGeometry, CoverMode, Slot};
 
 // ── public entry point ───────────────────────────────────────────────────────
 
@@ -116,7 +116,7 @@ fn cover_areas(cover: &CoverConfig, inner_page_count: usize) -> Result<CoverArea
     let clearance = cover.spine_clearance_mm;
     let canvas_h = cover.height_mm - 2.0 * margin;
     let half_fb = cover.front_back_width_mm / 2.0;
-    let spine_w = cover.spine_width_mm(inner_page_count);
+    let spine_w = CoverGeometry::new(cover, inner_page_count).spine_width_mm();
 
     if canvas_h <= 0.0 || cover.front_back_width_mm <= 0.0 {
         bail!(


### PR DESCRIPTION
Extracts spread_width_mm and spine_width_mm from CoverConfig into a
CoverGeometry value object that binds CoverConfig to a concrete
inner_page_count. CoverConfig methods now delegate to CoverGeometry;
the single correct CanvasConfig impl lives on CoverGeometry.