### PR TITLE
fix(deps): doppelten Scope in Dependabot-Commit-Präfixen entfernen

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,9 +25,12 @@ updates:
     allow:
       - dependency-type: all
     open-pull-requests-limit: 10
+    # `include: scope` haengt den Scope selbst an -- ergibt chore(deps) bzw.
+    # chore(deps-dev). Der Praefix darf die Klammer deshalb NICHT schon
+    # enthalten, sonst entsteht "chore(deps)(deps): ...".
     commit-message:
-      prefix: "chore(deps)"
-      prefix-development: "chore(deps-dev)"
+      prefix: "chore"
+      prefix-development: "chore"
       include: scope
     groups:
       # Ein Sammel-PR für alles, was ohne Breaking Change durchgeht.
@@ -52,7 +55,7 @@ updates:
       timezone: Europe/Berlin
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "chore"
       include: scope
     groups:
       uv-minor-patch:
@@ -75,7 +78,7 @@ updates:
       timezone: Europe/Berlin
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "ci(deps)"
+      prefix: "ci"
       include: scope
     groups:
       github-actions:

--- a/tests/dependabot_config_test.rs
+++ b/tests/dependabot_config_test.rs
@@ -142,3 +142,30 @@ fn no_workflow_merges_dependabot_pull_requests() {
         }
     }
 }
+
+/// `include: scope` laesst Dependabot den Scope selbst anhaengen -- aus
+/// `prefix: chore` wird `chore(deps): ...`. Traegt der Praefix die Klammer
+/// bereits, entsteht der doppelte Scope `chore(deps)(deps): ...`.
+#[test]
+fn commit_prefixes_do_not_duplicate_the_scope() {
+    let config = dependabot_config();
+
+    for entry in updates(&config) {
+        let commit_message = &entry["commit-message"];
+        if commit_message["include"].as_str() != Some("scope") {
+            continue;
+        }
+
+        for key in ["prefix", "prefix-development"] {
+            let Some(prefix) = commit_message[key].as_str() else {
+                continue;
+            };
+            assert!(
+                !prefix.contains('('),
+                "ecosystem {:?}: `{key}: {prefix}` traegt schon einen Scope, \
+                 zusammen mit `include: scope` ergibt das {prefix}(deps)",
+                entry["package-ecosystem"]
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`include: scope` weist Dependabot an, den Scope selbst zu ergänzen — aus `prefix: chore` wird `chore(deps)`, bei Entwicklungs-Abhängigkeiten `chore(deps-dev)`. In der mit #54 gemergten Konfiguration trugen die Präfixe die Klammer zusätzlich, sodass beides angewendet wurde.

Die daraufhin erzeugten PRs führten den Scope doppelt und waren damit keine gültigen Conventional Commits:

```
#60  ci(deps)(deps): bump the github-actions group with 5 updates
#59  chore(deps)(deps): bump the uv-minor-patch group across 1 directory with 2 updates
```

Da per Squash gemergt wird, wäre der doppelte Scope über den PR-Titel in Historie und Changelog gelandet.

## Änderung

Präfixe auf `chore` bzw. `ci` verkürzt, `include: scope` bleibt und erledigt den Rest. Betrifft alle drei Ökosysteme (cargo, uv, github-actions).

## Test

Neuer Test `commit_prefixes_do_not_duplicate_the_scope`: prüft für jeden Eintrag mit `include: scope`, dass `prefix` und `prefix-development` keine Klammer enthalten.

Gegengeprüft — mit der alten Konfiguration schlägt er fehl und benennt die Stelle:

```
ecosystem String("github-actions"): `prefix: ci(deps)` traegt schon einen Scope,
zusammen mit `include: scope` ergibt das ci(deps)(deps)
```

8 Tests grün, `cargo clippy` und `cargo fmt --check` sauber.

## Hinweis zu #59 und #60

Die Titel der beiden offenen PRs sind bereits von Hand korrigiert. Solange dieser Fix nicht auf `main` ist, kann Dependabot sie beim nächsten Neuaufbau wieder mit dem doppelten Scope überschreiben.
