### PR TITLE
fix(deps): commit-message-Konfiguration entfernen

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@
 # gemergt wird ausschließlich von Hand. Deshalb gibt es hier keinen
 # Auto-Merge-Workflow und keine `dependabot merge`-Automatik --
 # `tests/dependabot_config_test.rs` prüft das ab.
+# Kein `commit-message`-Block: Dependabot erkennt den Conventional-Commit-Stil
+# des Repositories selbst und setzt "chore(deps): ..." bereits von sich aus --
+# nachweisbar an PR #56/#57/#58, die entstanden, bevor es diese Datei gab. Ein
+# zusaetzliches `include: scope` haengt einen zweiten Scope an und erzeugt
+# "chore(deps)(deps): ...".
 version: 2
 
 updates:
@@ -25,13 +30,6 @@ updates:
     allow:
       - dependency-type: all
     open-pull-requests-limit: 10
-    # `include: scope` haengt den Scope selbst an -- ergibt chore(deps) bzw.
-    # chore(deps-dev). Der Praefix darf die Klammer deshalb NICHT schon
-    # enthalten, sonst entsteht "chore(deps)(deps): ...".
-    commit-message:
-      prefix: "chore"
-      prefix-development: "chore"
-      include: scope
     groups:
       # Ein Sammel-PR für alles, was ohne Breaking Change durchgeht.
       cargo-minor-patch:
@@ -54,9 +52,6 @@ updates:
       time: "06:00"
       timezone: Europe/Berlin
     open-pull-requests-limit: 5
-    commit-message:
-      prefix: "chore"
-      include: scope
     groups:
       uv-minor-patch:
         applies-to: version-updates
@@ -77,9 +72,6 @@ updates:
       time: "06:00"
       timezone: Europe/Berlin
     open-pull-requests-limit: 5
-    commit-message:
-      prefix: "ci"
-      include: scope
     groups:
       github-actions:
         patterns:

--- a/tests/dependabot_config_test.rs
+++ b/tests/dependabot_config_test.rs
@@ -143,29 +143,23 @@ fn no_workflow_merges_dependabot_pull_requests() {
     }
 }
 
-/// `include: scope` laesst Dependabot den Scope selbst anhaengen -- aus
-/// `prefix: chore` wird `chore(deps): ...`. Traegt der Praefix die Klammer
-/// bereits, entsteht der doppelte Scope `chore(deps)(deps): ...`.
+/// Dependabot erkennt den Conventional-Commit-Stil des Repositories selbst und
+/// setzt `chore(deps): ...` bereits von sich aus -- belegt durch PR #56/#57/#58,
+/// die entstanden, bevor `.github/dependabot.yml` existierte. Ein zusaetzliches
+/// `include: scope` haengt einen zweiten Scope an, woraus
+/// `chore(deps)(deps): ...` wird und damit kein gueltiger Conventional Commit
+/// mehr.
 #[test]
-fn commit_prefixes_do_not_duplicate_the_scope() {
+fn commit_message_scope_is_left_to_dependabot() {
     let config = dependabot_config();
 
     for entry in updates(&config) {
         let commit_message = &entry["commit-message"];
-        if commit_message["include"].as_str() != Some("scope") {
-            continue;
-        }
-
-        for key in ["prefix", "prefix-development"] {
-            let Some(prefix) = commit_message[key].as_str() else {
-                continue;
-            };
-            assert!(
-                !prefix.contains('('),
-                "ecosystem {:?}: `{key}: {prefix}` traegt schon einen Scope, \
-                 zusammen mit `include: scope` ergibt das {prefix}(deps)",
-                entry["package-ecosystem"]
-            );
-        }
+        assert!(
+            commit_message.is_null(),
+            "ecosystem {:?} setzt einen commit-message-Block; Dependabot setzt \
+             Typ und Scope selbst, jede eigene Angabe verdoppelt den Scope",
+            entry["package-ecosystem"]
+        );
     }
 }


### PR DESCRIPTION
Nachbesserung zu #61, das die Ursache nicht getroffen hat.

## Warum #61 nicht gereicht hat

#61 hat den Präfix von `chore(deps)` auf `chore` gekürzt, in der Annahme, die Klammer im Präfix sei die Ursache. Der Merge erfolgte um 08:54. Die danach von Dependabot erzeugten PRs #62–#71 tragen den doppelten Scope weiter — der Commit in #71 ist auf 09:16 datiert:

```
chore(deps)(deps): bump writeable from 0.6.3 to 0.6.4
```

## Die tatsächliche Ursache

`include: scope`. Dependabot erkennt den Conventional-Commit-Stil eines Repositories selbst und setzt Typ **und** Scope bereits von sich aus; `include: scope` hängt einen zweiten an.

Belegt durch #56/#57/#58: die entstanden, bevor `.github/dependabot.yml` überhaupt existierte (die Datei kam erst mit `acd6aa6`), und trugen ohne jede Konfiguration den korrekten Titel:

```
chore(deps): bump pypdf from 6.9.1 to 6.16.1 in /tests/tools
```

## Änderung

Die `commit-message`-Blöcke entfallen für alle drei Ökosysteme. Damit gilt wieder das Verhalten, das in diesem Repository nachweislich korrekte Titel erzeugt hat.

Einzige Auswirkung: `github-actions` bekommt künftig `chore(deps)` statt `ci(deps)`. `cliff.toml` ordnet `^chore` und `^ci` derselben Changelog-Gruppe (*Miscellaneous*) zu — am Changelog ändert sich nichts.

## Test

`commit_prefixes_do_not_duplicate_the_scope` prüfte nur die Schreibweise des Präfix und wäre bei dieser Ursache blind gewesen. Ersetzt durch `commit_message_scope_is_left_to_dependabot`, das anschlägt, sobald ein Ökosystem überhaupt einen `commit-message`-Block setzt.

8 Tests grün, `cargo clippy` und `cargo fmt --check` sauber.

## Danach

Die zehn offenen PRs #62–#71 behalten ihren falschen Titel. Nach dem Merge lässt sich das an einem kleinen PR sofort verifizieren, statt bis zum nächsten Wochenlauf zu warten — ein Kommentar `·@·d·ependabot r·ecreate` baut ihn mit der dann gültigen Konfiguration neu auf.
