### PR TITLE
fix(gui): gebrochenen GUI-Build reparieren und Dependabot-Familien gruppieren

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,29 @@ updates:
       - dependency-type: all
     open-pull-requests-limit: 10
     groups:
+      # Crate-Familien, die nur im Gleichschritt funktionieren. Wird nur ein
+      # Mitglied angehoben, liegen zwei Versionen derselben Bibliothek im
+      # Abhängigkeitsbaum und identisch benannte Typen sind nicht mehr
+      # zuweisungskompatibel ("expected typst::layout::Page, found
+      # typst_layout::document::Page"). Solche PRs können einzeln gar nicht
+      # grün werden -- siehe PR #64/#66/#70.
+      #
+      # Dependabot ordnet jede Abhängigkeit der *ersten* passenden Gruppe zu,
+      # deshalb stehen diese Gruppen vor `cargo-minor-patch`. Ohne
+      # `update-types` erfasst eine Gruppe alle Update-Arten, also auch
+      # Breaking Changes wie 0.14 -> 0.15.
+      typst:
+        applies-to: version-updates
+        patterns:
+          - "typst"
+          - "typst-*"
+      egui:
+        applies-to: version-updates
+        patterns:
+          - "eframe"
+          - "egui"
+          - "egui-*"
+          - "egui_*"
       # Ein Sammel-PR für alles, was ohne Breaking Change durchgeht.
       cargo-minor-patch:
         applies-to: version-updates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,13 @@ jobs:
       - name: Clippy
         run: cargo clippy -- -D warnings
 
+      # Die Coverage-Laeufe unten bauen nur die Default-Features. Optionale
+      # Features (gui, cli-docs, slow-tests) blieben dadurch ungetestet -- ein
+      # Dependency-Update konnte den GUI-Build brechen, ohne die CI rot zu
+      # faerben. Dieser Schritt kompiliert alle Features und alle Targets.
+      - name: Check all features
+        run: cargo check --all-features --all-targets
+
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,21 +1171,12 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "ecolor"
-version = "0.34.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05fbfa222ffb51989d5ccf33e5f7aebfcf96c5023413856b0c3618a7f79896e"
-dependencies = [
- "bytemuck",
- "emath 0.34.3",
-]
-
-[[package]]
-name = "ecolor"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6758be723a3f298bbfda4db75748bc2ba0abafe096b6383c7c32da264764fbc3"
 dependencies = [
- "emath 0.35.0",
+ "bytemuck",
+ "emath",
 ]
 
 [[package]]
@@ -1199,14 +1190,14 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.34.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98fe83b2589105b69dd25ca1e0fa2135a6e864d502fd8e08978f937e128cfef"
+checksum = "8dc8234e2f681b2afd2b2e8c332fa614de2fddbdcb28d0acf5c420449682ea90"
 dependencies = [
  "ahash",
  "bytemuck",
  "document-features",
- "egui 0.34.3",
+ "egui",
  "egui-wgpu",
  "egui-winit",
  "egui_glow",
@@ -1234,24 +1225,6 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.34.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42112be0ae157289312b92b3dfaf20e911b5a3c4c65d4aab0e7c47fbc0ce16e3"
-dependencies = [
- "accesskit",
- "ahash",
- "bitflags 2.13.0",
- "emath 0.34.3",
- "epaint 0.34.3",
- "log",
- "nohash-hasher",
- "profiling",
- "smallvec",
- "unicode-segmentation",
-]
-
-[[package]]
-name = "egui"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796c98d50b79631281d516343a6f6e93c0666462ca36e2c93b39f25d7793325"
@@ -1259,8 +1232,8 @@ dependencies = [
  "accesskit",
  "ahash",
  "bitflags 2.13.0",
- "emath 0.35.0",
- "epaint 0.35.0",
+ "emath",
+ "epaint",
  "itertools",
  "log",
  "nohash-hasher",
@@ -1271,15 +1244,15 @@ dependencies = [
 
 [[package]]
 name = "egui-wgpu"
-version = "0.34.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f0c0559ac5598a1b887a6206dccbab7e3e6246c57cb00ae287262bd44776c9c"
+checksum = "d2e6cfac0725563555fa4f91e9f799b9d7c6c5dd831fca6abc8234afc64b7a34"
 dependencies = [
  "ahash",
  "bytemuck",
  "document-features",
- "egui 0.34.3",
- "epaint 0.34.3",
+ "egui",
+ "epaint",
  "log",
  "profiling",
  "thiserror 2.0.18",
@@ -1291,13 +1264,13 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.34.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "967c5b323625d46d46a59b5daba3fef742248d27693cc18972458619858c4239"
+checksum = "9ea6bf3608db949588b95b8b341ee358d0c3f95cf4dc3f53d8d76717edee87db"
 dependencies = [
  "arboard",
  "bytemuck",
- "egui 0.34.3",
+ "egui",
  "log",
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",
@@ -1312,11 +1285,11 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55df531ff51161b3c6212e0ee2166b370f150254bf4448a8a15c3d26fec87958"
+checksum = "c833127228cc61cef806166adadc23572431fe2ea4cf753e60f654f82a2b3270"
 dependencies = [
- "egui 0.34.3",
+ "egui",
  "egui_commonmark_backend",
  "egui_extras",
  "pulldown-cmark",
@@ -1324,25 +1297,26 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_backend"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe04399ca5a2196965833a2918e50400449721fd9350e31ae7d84d6690859437"
+checksum = "5758a1110eb8259743c9b220241c30ff014b2dec53c1a2b861d464e41fa3483e"
 dependencies = [
- "egui 0.34.3",
+ "egui",
  "egui_extras",
  "pulldown-cmark",
 ]
 
 [[package]]
 name = "egui_extras"
-version = "0.34.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598d8675f6fd9088db8a93d8c7aacda936b2f3d0c2b0660ad1744a45b5caf922"
+checksum = "e2bd33be7338367bf21f54d62e069d58a5fb3ae033fa8bc6df7a77b9ef4cf957"
 dependencies = [
  "ahash",
- "egui 0.34.3",
+ "egui",
  "enum-map",
  "image",
+ "itertools",
  "log",
  "mime_guess2",
  "profiling",
@@ -1350,29 +1324,28 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.34.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b652957fa7e1ab01e8fecbfbf4e35f6e43a53fa98af8a562b50d5403cd44b9"
+checksum = "52274b9bfb8d8e252cd0f00c9f6214f360d75a0962baa77a2d62ddb002fe99d4"
 dependencies = [
  "bytemuck",
- "egui 0.34.3",
+ "egui",
  "glow",
  "log",
  "memoffset",
  "profiling",
- "wasm-bindgen",
- "web-sys",
  "winit",
 ]
 
 [[package]]
 name = "egui_kittest"
-version = "0.34.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cb65436bc6f214ecc8ef4d9056a9344f92e70e22c162dbc3d515913df0fd3c5"
+checksum = "002c31e1f41461ce206333ffbd2e07563b79e87eb71c27e026151d12ee7b78e0"
 dependencies = [
- "egui 0.34.3",
+ "egui",
  "kittest",
+ "log",
  "serde",
  "toml 1.1.2+spec-1.1.0",
 ]
@@ -1385,18 +1358,12 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "emath"
-version = "0.34.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53f0d33a479321da6b0caa71366c9f67e8a2c149762d90bdc0d16e601ee8ecb"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "emath"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd4ec073c9898516584d8c6cfdcee95b530b3d941cd5031ef4050aa36812308b"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "embedded-io"
@@ -1471,36 +1438,15 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.34.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6675898a291ec212fc3df04f537d177fce8496120244590e6359dcaa4c25da79"
-dependencies = [
- "ahash",
- "bytemuck",
- "ecolor 0.34.3",
- "emath 0.34.3",
- "epaint_default_fonts 0.34.3",
- "font-types 0.11.3",
- "log",
- "nohash-hasher",
- "parking_lot",
- "profiling",
- "self_cell",
- "skrifa 0.40.0",
- "smallvec",
- "vello_cpu 0.0.6",
-]
-
-[[package]]
-name = "epaint"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e60a8888b51da911df23918fd7301359b1d43a406a0ff3b8863af093dd7fc6c"
 dependencies = [
  "ahash",
- "ecolor 0.35.0",
- "emath 0.35.0",
- "epaint_default_fonts 0.35.0",
+ "bytemuck",
+ "ecolor",
+ "emath",
+ "epaint_default_fonts",
  "font-types 0.11.3",
  "harfrust",
  "log",
@@ -1512,14 +1458,8 @@ dependencies = [
  "smallvec",
  "unicode-general-category",
  "unicode-segmentation",
- "vello_cpu 0.0.9",
+ "vello_cpu",
 ]
-
-[[package]]
-name = "epaint_default_fonts"
-version = "0.34.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8970033a4282a7bcf899b38b5ed3a58b732fe093d03785d58648515d8d309da"
 
 [[package]]
 name = "epaint_default_fonts"
@@ -1629,15 +1569,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
-]
-
-[[package]]
-name = "fearless_simd"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb2907d1f08b2b316b9223ced5b0e89d87028ba8deae9764741dba8ff7f3903"
-dependencies = [
- "bytemuck",
 ]
 
 [[package]]
@@ -1814,7 +1745,7 @@ dependencies = [
  "crossbeam",
  "dirs 5.0.1",
  "eframe",
- "egui 0.35.0",
+ "egui",
  "egui_commonmark",
  "egui_kittest",
  "git2",
@@ -1988,7 +1919,7 @@ dependencies = [
  "peniko",
  "skrifa 0.42.1",
  "smallvec",
- "vello_common 0.0.9",
+ "vello_common",
 ]
 
 [[package]]
@@ -4485,16 +4416,6 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
-dependencies = [
- "bytemuck",
- "font-types 0.11.3",
-]
-
-[[package]]
-name = "read-fonts"
 version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
@@ -4959,16 +4880,6 @@ checksum = "8c31071dedf532758ecf3fed987cdb4bd9509f900e026ab684b4ecb81ea49841"
 dependencies = [
  "bytemuck",
  "read-fonts 0.35.0",
-]
-
-[[package]]
-name = "skrifa"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
-dependencies = [
- "bytemuck",
- "read-fonts 0.37.0",
 ]
 
 [[package]]
@@ -6169,44 +6080,18 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vello_common"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd1a4c633ce09e7d713df1a6e036644a125e15e0c169cfb5180ddf5836ca04b"
-dependencies = [
- "bytemuck",
- "fearless_simd 0.3.0",
- "hashbrown 0.16.1",
- "log",
- "peniko",
- "skrifa 0.40.0",
- "smallvec",
-]
-
-[[package]]
-name = "vello_common"
 version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d672facaa2d697285a786cd9d44d614cd2ce54cdc022504bf339f8fff3b750"
 dependencies = [
  "bytemuck",
- "fearless_simd 0.4.1",
+ "fearless_simd",
  "guillotiere",
  "hashbrown 0.17.1",
  "log",
  "peniko",
  "smallvec",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "vello_cpu"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162bfe48aabf6a9fdcd401b628c7d9f260c2cbabb343c70a65feba6f7849edc"
-dependencies = [
- "bytemuck",
- "hashbrown 0.16.1",
- "vello_common 0.0.6",
 ]
 
 [[package]]
@@ -6218,7 +6103,7 @@ dependencies = [
  "bytemuck",
  "glifo",
  "hashbrown 0.17.1",
- "vello_common 0.0.9",
+ "vello_common",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ cli-docs = ["dep:clap-markdown"]
 slow-tests = []
 
 [dependencies.eframe]
-version = "0.34"
+version = "0.35"
 optional = true
 default-features = false
 features = ["default_fonts", "glow", "x11"]
@@ -105,7 +105,7 @@ version = "0.17"
 optional = true
 
 [dependencies.egui_commonmark]
-version = "0.23"
+version = "0.24"
 optional = true
 
 [dependencies.include_dir]
@@ -134,7 +134,7 @@ codegen-units = 1
 [dev-dependencies]
 approx = "0.5"
 assert_cmd = "2"
-egui_kittest = "0.34"
+egui_kittest = "0.35"
 predicates = "3"
 proptest = "1"
 rand_chacha = "0.3"

--- a/gui/app/widgets/central_panel.rs
+++ b/gui/app/widgets/central_panel.rs
@@ -19,7 +19,7 @@ pub fn draw(
 ) {
     let resp = egui::CentralPanel::default()
         .frame(egui::Frame::new().fill(FbTheme::BG))
-        .show_inside(ui, |ui| {
+        .show(ui, |ui| {
             if let Some(h) = draw_pages::draw_pages(ui, data, interaction, cmds) {
                 interaction.hovered = Some(h);
             }

--- a/gui/app/widgets/central_panel/draw_pages.rs
+++ b/gui/app/widgets/central_panel/draw_pages.rs
@@ -35,7 +35,11 @@ pub(super) fn draw_pages(
     let mut sa = egui::ScrollArea::vertical()
         .auto_shrink([false; 2])
         .scroll_source(egui::containers::scroll_area::ScrollSource {
-            drag: !rmbactive,
+            drag: if rmbactive {
+                egui::containers::scroll_area::DragScroll::Never
+            } else {
+                egui::containers::scroll_area::DragScroll::Always
+            },
             scroll_bar: true,
             mouse_wheel: true,
         });

--- a/gui/app/widgets/help_window.rs
+++ b/gui/app/widgets/help_window.rs
@@ -52,7 +52,7 @@ fn draw_contents(ui: &mut egui::Ui, interaction: &mut InteractionState) {
     egui::Panel::left("help_sidebar")
         .resizable(true)
         .default_size(140.0)
-        .show_inside(ui, |ui| {
+        .show(ui, |ui| {
             egui::ScrollArea::vertical()
                 .id_salt("help_sidebar_scroll")
                 .show(ui, |ui| {

--- a/gui/app/widgets/page_nav.rs
+++ b/gui/app/widgets/page_nav.rs
@@ -14,7 +14,7 @@ pub fn draw(
         .min_size(100.0)
         .max_size(200.0)
         .default_size(120.0)
-        .show_inside(ui, |ui| show(ui, data, interaction, cmds));
+        .show(ui, |ui| show(ui, data, interaction, cmds));
 }
 
 fn show(

--- a/gui/app/widgets/photo_pool.rs
+++ b/gui/app/widgets/photo_pool.rs
@@ -9,7 +9,7 @@ pub fn draw(ui: &mut egui::Ui, data: &DataState, interaction: &mut InteractionSt
         .resizable(true)
         .min_size(120.0)
         .default_size(260.0)
-        .show_inside(ui, |ui| show(ui, data, interaction));
+        .show(ui, |ui| show(ui, data, interaction));
 }
 
 fn draw_pool_drag_ghost(ctx: &egui::Context, data: &DataState, interaction: &InteractionState) {
@@ -84,7 +84,11 @@ fn show(ui: &mut egui::Ui, data: &DataState, interaction: &mut InteractionState)
             ..egui::Margin::ZERO
         })
         .scroll_source(egui::containers::scroll_area::ScrollSource {
-            drag: !rmbactive,
+            drag: if rmbactive {
+                egui::containers::scroll_area::DragScroll::Never
+            } else {
+                egui::containers::scroll_area::DragScroll::Always
+            },
             scroll_bar: true,
             mouse_wheel: true,
         })
@@ -149,7 +153,7 @@ mod tests {
                     d.insert_persisted(
                         id,
                         egui::containers::panel::PanelState {
-                            rect: egui::Rect::from_min_size(
+                            outer_rect: egui::Rect::from_min_size(
                                 egui::pos2(0.0, 0.0),
                                 egui::vec2(MIN, 600.0),
                             ),
@@ -161,7 +165,7 @@ mod tests {
                     .resizable(true)
                     .min_size(MIN)
                     .default_size(260.0)
-                    .show_inside(ui, |ui| {
+                    .show(ui, |ui| {
                         egui::ScrollArea::vertical()
                             .auto_shrink([false; 2])
                             .show(ui, |ui| {

--- a/gui/app/widgets/statusbar.rs
+++ b/gui/app/widgets/statusbar.rs
@@ -1,7 +1,7 @@
 use crate::state::{ActiveDrag, DataState, HoveredTarget, InteractionState};
 
 pub fn draw(ui: &mut egui::Ui, data: &DataState, interaction: &InteractionState) {
-    egui::Panel::bottom("statusbar").show_inside(ui, |ui| show(ui, data, interaction));
+    egui::Panel::bottom("statusbar").show(ui, |ui| show(ui, data, interaction));
 }
 
 fn show(ui: &mut egui::Ui, data: &DataState, interaction: &InteractionState) {

--- a/gui/app/widgets/toolbar.rs
+++ b/gui/app/widgets/toolbar.rs
@@ -10,7 +10,7 @@ pub fn draw(
     interaction: &mut InteractionState,
 ) -> Vec<BackgroundTask> {
     egui::Panel::top("toolbar")
-        .show_inside(ui, |ui| show(ui, data, interaction))
+        .show(ui, |ui| show(ui, data, interaction))
         .inner
 }
 

--- a/tests/ci_workflow_test.rs
+++ b/tests/ci_workflow_test.rs
@@ -1,0 +1,46 @@
+//! Tests für den CI-Workflow (`.github/workflows/ci.yml`).
+//!
+//! Hintergrund: `cargo clippy` und `cargo llvm-cov` bauen nur die
+//! Default-Features. Optionale Features (`gui`, `cli-docs`, `slow-tests`)
+//! blieben dadurch komplett ungeprüft -- ein Dependency-Update konnte den
+//! GUI-Build brechen, ohne die CI rot zu färben (siehe PR #68: `egui` auf
+//! 0.35, `eframe` weiter auf 0.34).
+
+use std::path::PathBuf;
+
+fn ci_workflow() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".github/workflows/ci.yml");
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+/// Ohne diesen Schritt bleibt jedes optionale Feature ungebaut.
+#[test]
+fn ci_compiles_all_features() {
+    let workflow = ci_workflow();
+    assert!(
+        workflow.contains("cargo check --all-features --all-targets"),
+        "ci.yml baut nicht alle Features -- Brüche im gui-Feature bleiben unbemerkt"
+    );
+}
+
+/// Alle optionalen Features müssen von `--all-features` erfasst werden, also
+/// in `Cargo.toml` unter `[features]` deklariert sein. Ein Feature, das nur
+/// über eine optionale Dependency existiert, würde durchrutschen.
+#[test]
+fn every_optional_feature_is_declared() {
+    let manifest =
+        std::fs::read_to_string(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"))
+            .expect("cannot read Cargo.toml");
+
+    let features = manifest
+        .split("[features]")
+        .nth(1)
+        .expect("Cargo.toml hat keinen [features]-Abschnitt");
+
+    for expected in ["gui", "cli-docs", "slow-tests"] {
+        assert!(
+            features.contains(expected),
+            "Feature `{expected}` fehlt in [features] und würde von --all-features nicht erfasst"
+        );
+    }
+}

--- a/tests/dependabot_config_test.rs
+++ b/tests/dependabot_config_test.rs
@@ -163,3 +163,181 @@ fn commit_message_scope_is_left_to_dependabot() {
         );
     }
 }
+
+// --- Crate-Familien ------------------------------------------------------
+//
+// `typst`/`typst-pdf`/`typst-render`/`typst-kit` und `egui`/`eframe`/... sind
+// jeweils Familien, die nur im Gleichschritt funktionieren: wird ein einzelnes
+// Mitglied angehoben, liegen zwei Versionen derselben Bibliothek im
+// Abhängigkeitsbaum, und gleichnamige Typen aus verschiedenen Versionen sind
+// nicht zuweisungskompatibel. Einzel-PRs für Familienmitglieder können darum
+// grundsätzlich nicht grün werden.
+
+/// Direkte Abhängigkeiten aus `Cargo.toml` -- sowohl `name = "..."` innerhalb
+/// von `[dependencies]`/`[dev-dependencies]` als auch `[dependencies.name]`.
+fn direct_dependencies() -> Vec<String> {
+    let manifest =
+        std::fs::read_to_string(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"))
+            .expect("cannot read Cargo.toml");
+
+    let mut names = Vec::new();
+    let mut in_dependency_table = false;
+
+    for line in manifest.lines().map(str::trim) {
+        if let Some(section) = line.strip_prefix('[').and_then(|l| l.strip_suffix(']')) {
+            let section = section.trim_start_matches("[").trim_end_matches("]");
+            in_dependency_table = section == "dependencies" || section == "dev-dependencies";
+            if let Some(name) = section
+                .strip_prefix("dependencies.")
+                .or_else(|| section.strip_prefix("dev-dependencies."))
+            {
+                names.push(name.to_string());
+            }
+            continue;
+        }
+        if !in_dependency_table || line.starts_with('#') {
+            continue;
+        }
+        if let Some((name, _)) = line.split_once(" = ")
+            && !name.is_empty()
+            && name
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+        {
+            names.push(name.to_string());
+        }
+    }
+    names
+}
+
+/// Dependabot-Glob: nur ein abschließendes `*` ist zu unterstützen.
+fn pattern_matches(pattern: &str, name: &str) -> bool {
+    match pattern.strip_suffix('*') {
+        Some(prefix) => name.starts_with(prefix),
+        None => pattern == name,
+    }
+}
+
+/// Name der ersten Gruppe, die `name` erfasst -- Dependabot ordnet jede
+/// Abhängigkeit genau der ersten passenden Gruppe zu.
+fn group_of(entry: &Value, name: &str) -> Option<String> {
+    let groups = entry["groups"].as_mapping()?;
+    for (group_name, group) in groups {
+        if group["applies-to"].as_str() == Some("security-updates") {
+            continue;
+        }
+        let matches = match group["patterns"].as_sequence() {
+            Some(patterns) => patterns
+                .iter()
+                .filter_map(Value::as_str)
+                .any(|p| pattern_matches(p, name)),
+            // Ohne `patterns` erfasst eine Gruppe alles.
+            None => true,
+        };
+        if matches {
+            return Some(group_name.as_str()?.to_string());
+        }
+    }
+    None
+}
+
+fn assert_family_is_grouped(family: &str, members: &[&str]) {
+    let config = dependabot_config();
+    let cargo = entry_for(&config, "cargo");
+
+    let groups: Vec<Option<String>> = members.iter().map(|m| group_of(cargo, m)).collect();
+    let first = groups[0].clone();
+
+    assert!(
+        first.is_some(),
+        "{family}: `{}` ist keiner Gruppe zugeordnet",
+        members[0]
+    );
+    for (member, group) in members.iter().zip(&groups) {
+        assert_eq!(
+            group, &first,
+            "{family}: `{member}` landet in Gruppe {group:?}, `{}` aber in {first:?} -- \
+             getrennte PRs für Familienmitglieder können nicht kompilieren",
+            members[0]
+        );
+    }
+
+    // Eine Gruppe mit `update-types: [minor, patch]` lässt Breaking Changes
+    // (0.14 -> 0.15) durchfallen; genau die werden dann zu Einzel-PRs.
+    let group_name = first.expect("Familie ist keiner Gruppe zugeordnet");
+    let group = &cargo["groups"][group_name.as_str()];
+    assert!(
+        group["update-types"].is_null(),
+        "{family}: Gruppe `{group_name}` schränkt update-types ein -- \
+         Breaking Changes der Familie kämen weiterhin als Einzel-PRs"
+    );
+}
+
+/// Jede direkte Abhängigkeit der Familie muss abgedeckt sein, auch eine
+/// später hinzugefügte.
+fn family_members(prefixes: &[&str]) -> Vec<String> {
+    let mut members: Vec<String> = direct_dependencies()
+        .into_iter()
+        .filter(|d| {
+            prefixes.iter().any(|p| {
+                d == p || d.starts_with(&format!("{p}-")) || d.starts_with(&format!("{p}_"))
+            })
+        })
+        .collect();
+    members.sort();
+    members.dedup();
+    members
+}
+
+#[test]
+fn typst_crates_share_one_group() {
+    let members = family_members(&["typst"]);
+    assert!(
+        members.len() > 1,
+        "keine typst-Familie in Cargo.toml gefunden -- Test veraltet?"
+    );
+    let refs: Vec<&str> = members.iter().map(String::as_str).collect();
+    assert_family_is_grouped("typst", &refs);
+}
+
+#[test]
+fn egui_crates_share_one_group() {
+    let mut members = family_members(&["egui"]);
+    if direct_dependencies().iter().any(|d| d == "eframe") {
+        members.push("eframe".to_string());
+    }
+    assert!(
+        members.len() > 1,
+        "keine egui-Familie in Cargo.toml gefunden -- Test veraltet?"
+    );
+    let refs: Vec<&str> = members.iter().map(String::as_str).collect();
+    assert_family_is_grouped("egui", &refs);
+}
+
+/// Familiengruppen müssen vor der Sammelgruppe stehen, sonst schluckt diese
+/// die Mitglieder zuerst.
+#[test]
+fn family_groups_precede_the_catch_all_group() {
+    let config = dependabot_config();
+    let cargo = entry_for(&config, "cargo");
+    let groups = cargo["groups"]
+        .as_mapping()
+        .expect("cargo hat keine groups");
+
+    let order: Vec<&str> = groups.keys().filter_map(Value::as_str).collect();
+    let catch_all = order
+        .iter()
+        .position(|g| *g == "cargo-minor-patch")
+        .expect("Gruppe cargo-minor-patch fehlt");
+
+    for family in ["typst", "egui"] {
+        let idx = order
+            .iter()
+            .position(|g| *g == family)
+            .unwrap_or_else(|| panic!("Gruppe {family} fehlt"));
+        assert!(
+            idx < catch_all,
+            "Gruppe {family} steht hinter cargo-minor-patch und greift deshalb nie"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

`main` lässt sich derzeit nicht mit dem `gui`-Feature bauen:

```
$ cargo check --features gui
error[E0308]: mismatched types
   --> gui/main.rs:63:19
    = note: there are multiple different versions of crate `egui` in the dependency graph
error: could not compile `fotobuch` (bin "fotobuch-gui") due to 7 previous errors
```

PR #68 hat `egui` auf 0.35 angehoben, während `eframe` (0.34), `egui_kittest` (0.34) und `egui_commonmark` (0.23) weiterhin egui 0.34 mitgezogen haben. Zwei Versionen derselben Bibliothek im Abhängigkeitsbaum bedeuten, dass gleichnamige Typen nicht mehr zuweisungskompatibel sind.

Die CI hat das nicht gemeldet, weil `cargo clippy` und `cargo llvm-cov` nur die Default-Features bauen. `gui`, `cli-docs` und `slow-tests` sind optional und wurden nie kompiliert.

Dieselbe Ursache blockiert die offenen Dependabot-PRs #66 (`typst-pdf` 0.15) und #70 (`typst-render` 0.15): `typst`, `typst-pdf`, `typst-render` und `typst-kit` sind eine Familie, die nur im Gleichschritt funktioniert. Einzeln angehoben liefern sie `expected typst_layout::document::PagedDocument, found typst::layout::PagedDocument`. Diese PRs können grundsätzlich nicht grün werden.

## Änderungen

**`fix(gui)`: egui-Familie auf 0.35 synchronisieren**
- `eframe` und `egui_kittest` auf 0.35, `egui_commonmark` auf 0.24 (erste Version, die egui 0.35 verlangt). Danach liegt genau eine egui-Version im Lockfile.
- API-Änderungen von egui 0.35 nachgezogen:
  - `ScrollSource::drag` ist kein `bool` mehr, sondern `DragScroll`. `!rmbactive` wird zu `Never`/`Always` — das bildet das bisherige Verhalten exakt ab, weil `true` Drag-Scrolling auch mit der Maus erlaubte.
  - `PanelState::rect` heißt `outer_rect`.
  - `show_inside` ist deprecated, jetzt `show`.

**`ci`: alle Features im CI-Lauf kompilieren**
- Neuer Schritt `cargo check --all-features --all-targets` vor dem Coverage-Lauf. `check` linkt nicht und braucht daher keine zusätzlichen System-Bibliotheken auf dem Runner.

**`ci(deps)`: typst- und egui-Crates als Familie gruppieren**
- Zwei neue Dependabot-Gruppen ohne `update-types`, damit sie auch Breaking Changes wie 0.14 → 0.15 erfassen. Sie stehen vor `cargo-minor-patch`, weil Dependabot jede Abhängigkeit der ersten passenden Gruppe zuordnet.

## Tests

- `tests/ci_workflow_test.rs` (neu): sichert den `--all-features`-Schritt und die Deklaration der optionalen Features ab.
- `tests/dependabot_config_test.rs`: Familien-Tests. Die Mitglieder werden aus `Cargo.toml` abgeleitet, damit eine später hinzugefügte typst-/egui-Kiste nicht stillschweigend herausfällt. Geprüft wird zusätzlich, dass die Familiengruppe keine `update-types`-Einschränkung trägt und vor der Sammelgruppe steht — sonst greift sie nie.
- Gegenprobe: ohne die neuen Gruppen schlagen die drei Familien-Tests fehl.
- `cargo test --features gui` läuft vollständig durch, `cargo fmt --check` und `cargo clippy -- -D warnings` sind sauber.

## Folgearbeiten

- #62 hat einen `Cargo.lock`-Konflikt; ein Dependabot-Rebase ist dort angestoßen.
- #64 wird durch diesen PR überholt und kann geschlossen werden.
- #66 und #70 schließen — nach dem Merge schlägt Dependabot die typst-Familie als einen gemeinsamen PR vor.
- `cargo clippy --all-targets` meldet vorbestehende Warnungen in Test-Targets, die die CI bisher nicht gesehen hat. Die werden separat aufgeräumt.